### PR TITLE
refactor(config): deprecate article default image

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -47,14 +47,6 @@ DefaultContentLanguage = "en"                   # Theme i18n support
             site = ""
             card = "summary_large_image"
     [params.defaultImage]
-        [params.defaultImage.article]
-            enabled = false
-            local = false
-            src = ""
-        [params.defaultImage.articleList]
-            enabled = false
-            local = true
-            src = ""
         [params.defaultImage.opengraph]
             enabled = false
             local = false


### PR DESCRIPTION
Remove [params.defaultImage.article] and [params.defaultImage.articleList] from config.toml

Those configs still works, but I do not encourage its usage.