### PR TITLE
fix(article): last updated time error

### DIFF
--- a/exampleSite/content/page/about.md
+++ b/exampleSite/content/page/about.md
@@ -5,6 +5,7 @@ date = "2019-02-28"
 aliases = ["about-us", "about-hugo", "contact"]
 author = "Hugo Authors"
 license = "CC BY-NC-ND"
+lastmod = "2020-10-09"
 +++
 
 Written in Go, Hugo is an open source static site generator available under the [Apache Licence 2.0.](https://github.com/gohugoio/hugo/blob/master/LICENSE) Hugo supports TOML, YAML and JSON data file types, Markdown and HTML content files and uses shortcodes to add rich content. Other notable features are taxonomies, multilingual mode, image processing, custom output formats, HTML/CSS/JS minification and support for Sass SCSS workflows.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -5,7 +5,7 @@
     other = "Related contents"
 
 [lastUpdatedOn]
-    other ="Last updated on {{ . }}"
+    other ="Last updated on"
 
 [widgetArchivesTitle]
     other = "Archives"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -5,7 +5,7 @@
     other = "Related contents"
 
 [lastUpdatedOn]
-    other ="Last updated on {{ .Count }}"
+    other ="Last updated on {{ . }}"
 
 [widgetArchivesTitle]
     other = "Archives"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -5,7 +5,7 @@
     other = "相关文章"
 
 [lastUpdatedOn]
-    other ="最后更新于 {{ . }}"
+    other ="最后更新于"
 
 [widgetArchivesTitle]
     other = "归档"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -5,7 +5,7 @@
     other = "相关文章"
 
 [lastUpdatedOn]
-    other ="最后更新于 {{ .Count }}"
+    other ="最后更新于 {{ . }}"
 
 [widgetArchivesTitle]
     other = "归档"

--- a/layouts/partials/article/components/footer.html
+++ b/layouts/partials/article/components/footer.html
@@ -12,7 +12,7 @@
     <section class="article-time">
         {{ (resources.Get "icons/clock.svg").Content | safeHTML }}
         <span class="article-time--modified">
-            {{ T "lastUpdatedOn" (.Lastmod.Format ( or .Site.Params.dateFormat.lastUpdated "Jan 02, 2006 15:04 MST" )) }} 
+            {{ T "lastUpdatedOn" }} {{ .Lastmod.Format ( or .Site.Params.dateFormat.lastUpdated "Jan 02, 2006 15:04 MST" ) }}
         </span>
     </section>
     {{- end -}}


### PR DESCRIPTION
> can't evaluate field Count in type string
![09-13-35-27](https://user-images.githubusercontent.com/48500247/95543768-5d9bc980-0a34-11eb-9253-deb8a412e0f8.png)

Count could not be displayed when using `.Count`, so this has been changed.