### PR TITLE
Fix categories with special char or spaces not displayed correctly

### DIFF
--- a/exampleSite/content/post/chinese-test/index.md
+++ b/exampleSite/content/post/chinese-test/index.md
@@ -1,11 +1,12 @@
 ---
-title: 中文文章内容测试
+title: Chinese Test
 description: 这是一个副标题
 date: 2020-09-09
 slug: test-chinese
 image: helena-hertz-wWZzXlDpMog-unsplash.jpg
 categories:
     - Test
+    - 测试
 ---
 
 ## 正文测试

--- a/exampleSite/content/post/placeholder-text/index.md
+++ b/exampleSite/content/post/placeholder-text/index.md
@@ -4,11 +4,13 @@ title = "Placeholder Text"
 date = "2019-03-09"
 description = "Lorem Ipsum Dolor Si Amet"
 categories = [
-    "Test"
+    "Test",
+    "Test with whitespaces"
 ]
 tags = [
     "markdown",
     "text",
+    "tag with whitespaces"
 ]
 image = "matt-le-SJSpo9hQf7s-unsplash.jpg"
 +++

--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -1,18 +1,16 @@
 {{ $image := partialCached "helper/image" (dict "Context" . "Type" "article") .RelPermalink "article" }}
 {{- $context := . -}}
-{{- $categories := .Params.categories -}}
 <div class="article-details">
-    {{ if $categories }}
+    {{ if .Params.categories }}
     <header class="article-category">
-        {{ range $category := $categories }}
-            {{ $term := $.Site.GetPage (printf "/categories/%s" $category | urlize ) }}
+        {{ range (.GetTerms "categories") }}
             {{ if and $image.exists $image.resource }}
                 {{- $imageRaw := $image.resource | resources.Fingerprint "md5"  -}}
                 {{- $20x := $imageRaw.Fill "20x20 smart"  -}}
-                <a href="{{ $term.Permalink }}" class="color-tag"
-                    data-image="{{ $20x.RelPermalink }}" data-key="{{ $context.Slug }}" data-hash="{{ $imageRaw.Data.Integrity }}">{{ $term.Title | humanize }}</a>
+                <a href="{{ .Permalink }}" class="color-tag"
+                    data-image="{{ $20x.RelPermalink }}" data-key="{{ $context.Slug }}" data-hash="{{ $imageRaw.Data.Integrity }}">{{ .LinkTitle | humanize }}</a>
             {{ else }}
-                <a href="{{ $term.Permalink }}">{{ $term.Title | humanize }}</a>
+                <a href="{{ .Permalink }}">{{ .LinkTitle | humanize }}</a>
             {{ end }}
         {{ end }}
     </header>

--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -5,7 +5,7 @@
     {{ if $categories }}
     <header class="article-category">
         {{ range $category := $categories }}
-            {{ $term := $.Site.GetPage (printf "/categories/%s" $category) }}
+            {{ $term := $.Site.GetPage (printf "/categories/%s" $category | urlize ) }}
             {{ if and $image.exists $image.resource }}
                 {{- $imageRaw := $image.resource | resources.Fingerprint "md5"  -}}
                 {{- $20x := $imageRaw.Fill "20x20 smart"  -}}

--- a/layouts/partials/article/components/tags.html
+++ b/layouts/partials/article/components/tags.html
@@ -1,10 +1,7 @@
-{{- $tags := .Params.Tags -}}
-{{ if $tags }}
+{{ if .Params.Tags }}
     <section class="article-tags">
-        {{ range $tag := $tags }}
-            {{ with $.Site.GetPage (printf "/tags/%s" $tag) }}
-                <a href="{{ .Permalink }}">{{ .Title | humanize }}</a>
-            {{ end }}
+        {{ range (.GetTerms "tags") }}
+            <a href="{{ .Permalink }}">{{ .LinkTitle | humanize }}</a>
         {{ end }}
     </section>
 {{ end }}

--- a/layouts/partials/widget/tag-cloud.html
+++ b/layouts/partials/widget/tag-cloud.html
@@ -1,5 +1,3 @@
-{{ $tags := .Site.Taxonomies.tags.ByCount }}
-
 <section class="widget tagCloud">
     <div class="widget-icon">
         {{ (resources.Get "icons/tag.svg").Content | safeHTML }}
@@ -7,10 +5,9 @@
     <h1 class="widget-title">{{ T "widgetTagCloudTitle" }}</h1>
 
     <div class="tagCloud-tags">
-        {{ range first .Site.Params.widgets.tagCloud.limit $tags }}
-            {{ $term := $.Site.GetPage (printf "/tags/%s" .Term) }}
-            <a href="{{ $term.Permalink }}" class="font_size_{{ .Count }}">
-                {{ $term.Title | humanize }}
+        {{ range first .Site.Params.widgets.tagCloud.limit .Site.Taxonomies.tags.ByCount }}
+            <a href="{{ .Page.Permalink }}" class="font_size_{{ .Count }}">
+                {{ .Page.Title | humanize }}
             </a>
         {{ end }}
     </div>


### PR DESCRIPTION
Hello,

Here is a small fix to call [`urlize`](https://gohugo.io/functions/urlize/) to get the category URL instead of using its name directly. Before this fix it was not working with categories containing special character or white spaces.

Best.