### PR TITLE
Support subtitle param as article subtitle if description not defined

### DIFF
--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -22,7 +22,7 @@
         </a>
     </h2>
 
-    {{ with .Params.description }}
+    {{ with or .Params.description .Params.subtitle }}
     <h3 class="article-subtitle">
         {{ . }}
     </h3>


### PR DESCRIPTION
Hello,

Just a small change to support the article param `subtitle` that is sometimes used (see an [example](https://gohugo.io/templates/homepage/#example-homepage-template)) if `description` is not defined.

Best.