### PR TITLE
layout: hide emoji circle when emoji is empty

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -30,3 +30,18 @@
 
 [searchResultTitle]
     other = "#PAGES_COUNT pages (#TIME_SECONDS seconds)"
+
+[searchResultPost]
+    other = "Post"
+
+[categories]
+    other = "Categories"
+
+[category]
+    other = "Category"
+
+[footerBuiltWith]
+    other = "Built with"
+
+[footerDesignedBy]
+    other = "designed by"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,32 @@
+[toggleMenu]
+    other = "Afficher le menu"
+    
+[relatedContents]
+    other = "Contenus liés"
+
+[lastUpdatedOn]
+    other = "Dernière mise à jour le"
+
+[widgetArchivesTitle]
+    other = "Archives"
+
+[widgetArchivesMore]
+    other = "Autres"
+
+[widgetTagCloudTitle]
+    other = "Mots clés"
+
+[notFoundTitle]
+    other = "Page non trouvée"
+
+[notFoundSubtitle]
+    other = "Cette page n'existe pas."
+
+[searchTitle]
+    other = "Rechercher"
+
+[searchPlaceholder]
+    other = "Cherchez un article, une publication, etc."
+
+[searchResultTitle]
+    other = "#PAGES_COUNT pages (#TIME_SECONDS secondes)"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -30,3 +30,18 @@
 
 [searchResultTitle]
     other = "#PAGES_COUNT pages (#TIME_SECONDS secondes)"
+
+[searchResultPost]
+    other = "Publication"
+
+[categories]
+    other = "Catégories"
+
+[category]
+    other = "Catégorie"
+
+[footerBuiltWith]
+    other = "Généré avec"
+
+[footerDesignedBy]
+    other = "conçu par"

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,7 +2,7 @@
 {{ define "main" }}
     {{ $categories := ($.Site.GetPage "taxonomyTerm" "categories").Pages }}
     {{ if $categories }}
-    <h2 class="section-title">Categories</h2>
+    <h2 class="section-title">{{ T "categories" }}</h2>
     <div class="category-list">
         <div class="article-list--tile">
             {{ range $categories }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
-    <h3 class="taxonomy-type section-title">{{ .Type | singularize | humanize }}</h3>
+    <h3 class="taxonomy-type section-title">{{ T "category" }}</h3>
     <div class="taxonomy-card">
         <div class="taxonomy-details">
-            <h3 class="taxonomy-count">{{ len .Pages }} post{{ if gt (len .Pages) 1 }}s{{ end }}</h3>
+            <h3 class="taxonomy-count">{{ len .Pages }} {{ T "searchResultPost" }}{{ if gt (len .Pages) 1 }}s{{ end }}</h3>
             <h1 class="taxonomy-term">{{ .Title }}</h1>
             {{ with .Params.description }}
                 <h2 class="taxonomy-description">{{ . }}</h2>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,8 +1,8 @@
 <footer class="site-footer">
     <section class="copyright">&copy; {{ now.Format "2006" }} {{ .Site.Title }}</section>
     <section class="powerby">
-        Built with <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> <br />
-        Theme <b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="1.1.0">Stack</a></b> designed by
+        {{ T "footerBuiltWith" }} <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> <br />
+        Theme <b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="1.1.0">Stack</a></b> {{ T "footerDesignedBy" }}
         <a href="https://jimmycai.com" target="_blank" rel="noopener">Jimmy</a>
     </section>
 </footer>

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -18,7 +18,9 @@
                     {{ errorf "Failed loading avatar from %q" . }}
                 {{ end }}
 
-                <span class="emoji">{{ $.Site.Params.sidebar.emoji }}</span>
+                {{ if $.Site.Params.sidebar.emoji }}
+                    <span class="emoji">{{ $.Site.Params.sidebar.emoji }}</span>
+                {{ end }}
             </figure>
         {{ end }}
         <h1 class="site-name"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>


### PR DESCRIPTION
Hi, here's a small proposition : I think when emoji is empty in the `config.toml`, the blank circle should not be displayed. What do you think?

### Description and illustration : 
Before this commit :
![Old](https://i.ibb.co/cQvpJ8p/Screen-Shot-2020-11-18-at-16-09-10.png)

After : 
![New](https://i.ibb.co/dpcwKPv/Screen-Shot-2020-11-18-at-16-11-37.png)

### Translation stuff
I did some work on translation but I was not working on a separate branch so everything is in the same pull request.
So to recap what I've done : 
- Added French translations
- Then added some missing translations, there's one in particular where I've been obligated to split in 2 translation for singular and plurial, I explained everything in the commit message: https://github.com/CaiJimmy/hugo-theme-stack/pull/49/commits/3423a92749ed49717546a3b4247aa373bd8c5f16

Thank you