### PR TITLE
i18n: added french translations & footer translation

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -32,7 +32,7 @@
     other = "#PAGES_COUNT pages (#TIME_SECONDS seconds)"
 
 [footerBuiltWith]
-    other = "Built with"
-
+    other = "Built with {{ .Generator }}"
+    
 [footerDesignedBy]
-    other = "designed by"
+    other = "Theme {{ .Theme }} designed by {{ .DesignedBy }}"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -30,3 +30,9 @@
 
 [searchResultTitle]
     other = "#PAGES_COUNT pages (#TIME_SECONDS seconds)"
+
+[footerBuiltWith]
+    other = "Built with"
+
+[footerDesignedBy]
+    other = "designed by"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -30,3 +30,9 @@
 
 [searchResultTitle]
     other = "#PAGES_COUNT pages (#TIME_SECONDS secondes)" 
+
+[footerBuiltWith]
+    other = "Généré avec"
+
+[footerDesignedBy]
+    other = "conçu par"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -32,7 +32,7 @@
     other = "#PAGES_COUNT pages (#TIME_SECONDS secondes)" 
 
 [footerBuiltWith]
-    other = "Généré avec"
+    other = "Généré avec {{ .Generator }}"
 
 [footerDesignedBy]
-    other = "conçu par"
+    other = "Thème {{ .Theme }} conçu par {{ .DesignedBy }}"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,32 @@
+[toggleMenu]
+    other = "Afficher le menu"
+
+[relatedContents]
+    other = "Contenus liés"
+
+[lastUpdatedOn]
+    other = "Dernière mise à jour le"
+
+[widgetArchivesTitle]
+    other = "Archives"
+
+[widgetArchivesMore]
+    other = "Autres"
+
+[widgetTagCloudTitle]
+    other = "Mots clés"
+
+[notFoundTitle]
+    other = "Page non trouvée"
+
+[notFoundSubtitle]
+    other = "Cette page n'existe pas."
+
+[searchTitle]
+    other = "Rechercher"
+
+[searchPlaceholder]
+    other = "Cherchez un article, une publication, etc."
+
+[searchResultTitle]
+    other = "#PAGES_COUNT pages (#TIME_SECONDS secondes)" 

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,8 +1,8 @@
 <footer class="site-footer">
     <section class="copyright">&copy; {{ now.Format "2006" }} {{ .Site.Title }}</section>
     <section class="powerby">
-        Built with <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> <br />
-        Theme <b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="1.1.0">Stack</a></b> designed by
+        {{ T "footerBuiltWith" }} <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> <br />
+        Theme <b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="1.1.0">Stack</a></b> {{ T "footerDesignedBy" }}
         <a href="https://jimmycai.com" target="_blank" rel="noopener">Jimmy</a>
     </section>
 </footer>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,8 +1,12 @@
+{{- $ThemeVersion := "1.1.0" -}}
 <footer class="site-footer">
     <section class="copyright">&copy; {{ now.Format "2006" }} {{ .Site.Title }}</section>
     <section class="powerby">
-        {{ T "footerBuiltWith" }} <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> <br />
-        Theme <b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="1.1.0">Stack</a></b> {{ T "footerDesignedBy" }}
-        <a href="https://jimmycai.com" target="_blank" rel="noopener">Jimmy</a>
+        {{- $Generator := `<a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a>` -}}
+        {{- $Theme := printf `<b><a href="https://github.com/CaiJimmy/hugo-theme-stack" target="_blank" rel="noopener" data-version="%s">Stack</a></b>` $ThemeVersion -}}
+        {{- $DesignedBy := `<a href="https://jimmycai.com" target="_blank" rel="noopener">Jimmy</a>` -}}
+
+        {{ T "footerBuiltWith" (dict "Generator" $Generator) | safeHTML }} <br />
+        {{ T "footerDesignedBy" (dict "Theme" $Theme "DesignedBy" $DesignedBy) | safeHTML }}
     </section>
 </footer>


### PR DESCRIPTION
I didn't re-added translations of "posts" and "categories" title, I don't want to break taxonomies and cause problems with plurials terminations. So it's only some basics translations here.