### PR TITLE
feat(sidebar): add support for external avatar

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,8 +21,10 @@ DefaultContentLanguage = "en"                   # Theme i18n support
         
     [params.sidebar]
         emoji = "🍥"
-        avatar = "img/avatar.png"
         subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        [params.sidebar.avatar]
+            local = true
+            src = "img/avatar.png"
         
     [params.article]
         math = false

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -8,10 +8,10 @@
     <header class="site-info">
         {{ with .Site.Params.sidebar.avatar }}
             <figure class="site-avatar">
-                {{ if in (.) "http" }}
-                    <img src="{{ . }}" width="300" height="300" class="site-logo" loading="lazy" alt="Avatar">
+                {{ if not .local }}
+                    <img src="{{ .src }}" width="300" height="300" class="site-logo" loading="lazy" alt="Avatar">
                 {{ else }}
-                    {{$avatar := resources.Get (.) }}
+                    {{ $avatar := resources.Get (.src) }}
                     
                     {{ if $avatar }}
                         {{ $avatarResized := $avatar.Resize "300x" }}

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -8,16 +8,20 @@
     <header class="site-info">
         {{ with .Site.Params.sidebar.avatar }}
             <figure class="site-avatar">
-                {{ $avatar := resources.Get (.) }}
-
-                {{ if $avatar }}
-                    {{ $avatarResized := $avatar.Resize "300x300" }}
-                    <img src="{{ $avatarResized.RelPermalink }}" width="{{ $avatarResized.Width }}"
-                        height="{{ $avatarResized.Height }}" class="site-logo" loading="lazy" alt="Avatar">
+                {{ if in (.) "http" }}
+                    <img src="{{ . }}" width="300" height="300" class="site-logo" loading="lazy" alt="Avatar">
                 {{ else }}
-                    {{ errorf "Failed loading avatar from %q" . }}
+                    {{$avatar := resources.Get (.) }}
+                    
+                    {{ if $avatar }}
+                        {{ $avatarResized := $avatar.Resize "300x" }}
+                        <img src="{{ $avatarResized.RelPermalink }}" width="{{ $avatarResized.Width }}"
+                            height="{{ $avatarResized.Height }}" class="site-logo" loading="lazy" alt="Avatar">
+                    {{ else }}
+                        {{ errorf "Failed loading avatar from %q" . }}
+                    {{ end }}
                 {{ end }}
-
+                
                 <span class="emoji">{{ $.Site.Params.sidebar.emoji }}</span>
             </figure>
         {{ end }}


### PR DESCRIPTION
It's a bit ugly, but I did a test to fix the issue #50.

The actual problem is that GoHugo does not offer any conditionals to test if a variable is a URL, also `resources.Get` only works with local files, it does not load external resources.

This workaround works but it's certainly not the best way.