### PR TITLE
fix(article): twitter_simple shortcode text color

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -305,4 +305,8 @@
     tr:nth-child(even) {
         background-color: var(--tr-even-background-color);
     }
+
+    .twitter-tweet {
+        color: var(--card-text-color-main);
+    }
 }


### PR DESCRIPTION
closes https://github.com/CaiJimmy/hugo-theme-stack/issues/85