### PR TITLE
refactor(archives): remove archive.categories i18n item

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -16,10 +16,6 @@ list:
         one: Subsection
         other: Subsections
 
-archives:
-    categories:
-        other: Categories
-
 article:
     relatedContents:
         other: Related contents

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -4,10 +4,6 @@ toggleMenu:
 darkMode:
     other: ダークモード
 
-archives:
-    categories:
-        other: 分類
-
 article:
     relatedContents:
         other: 関連するコンテンツ

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -1,10 +1,6 @@
 toggleMenu:
     other: Alternar Menu
 
-archives:
-    categories:
-        other: Categorias
-
 article:
     relatedContents:
         other: Conteúdos Relacionados

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -20,10 +20,6 @@ list:
         many: Подразделов
         other: Подразделов
 
-archives:
-    categories:
-        other: Категории
-
 article:
     relatedContents:
         other: Также рекомендуем

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -16,10 +16,6 @@ list:
         one: Alt bölüm
         other: Alt bölümler
 
-archives:
-    categories:
-        other: Kategoriler
-
 article:
     relatedContents:
         other: Alakalı içerikler

--- a/i18n/zh-CN.yaml
+++ b/i18n/zh-CN.yaml
@@ -4,10 +4,6 @@ toggleMenu:
 darkMode:
     other: 暗色模式
 
-archives:
-    categories:
-        other: 分类
-
 article:
     relatedContents:
         other: 相关文章

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,11 +1,12 @@
 {{ define "body-class" }}template-archives{{ end }}
 {{ define "main" }}
-    {{ $categories := ($.Site.GetPage "taxonomyTerm" "categories").Pages }}
-    {{ if $categories }}
-    <h2 class="section-title">{{ T "archives.categories" }}</h2>
+    {{- $taxonomy := $.Site.GetPage "taxonomyTerm" "categories" -}}
+    {{- $terms := $taxonomy.Pages -}}
+    {{ if $terms }}
+    <h2 class="section-title">{{ $taxonomy.Title }}</h2>
     <div class="subsection-list">
         <div class="article-list--tile">
-            {{ range $categories }}
+            {{ range $terms }}
                 {{ partial "article-list/tile" (dict "context" . "size" "250x150" "Type" "taxonomy") }}
             {{ end }}
         </div>


### PR DESCRIPTION
It's possible in the future to display another kind of taxonomy.

To translate that title, create _index.md under `content/categories`, with the following content:

```
---
title: Category
---
```

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/95