### PR TITLE
feat(list): display subsections in list style when there are no normal pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,8 +42,17 @@
         {{ end }}
     </div>
 
-    {{ $subsections := .Sections }}
-    {{ with $subsections }}
+    {{- $subsections := .Sections -}}
+    {{- $pages := .Pages | complement $subsections -}}
+    
+    {{- if eq (len $pages) 0 -}}
+        {{/* If there are no normal pages, display subsections in list style, with pagination */}}
+        {{/* This happens with taxonomies like categories or tags */}}
+        {{- $pages = $subsections -}}
+        {{- $subsections = slice -}}
+    {{- end -}}
+
+    {{- with $subsections -}}
         <h2 class="section-title">{{ T "list.subsection" (len $subsections) }}</h2>
         <div class="subsection-list">
             <div class="article-list--tile">
@@ -52,10 +61,10 @@
                 {{ end }}
             </div>
         </div>
-    {{ end }}
+    {{- end -}}
     
     {{/* List only pages that are not a subsection */}}
-    {{ $paginator := .Paginate (.Pages | complement $subsections) }}
+    {{ $paginator := .Paginate $pages }}
     <section class="article-list--compact">
         {{ range $paginator.Pages }}
             {{ partial "article-list/compact" . }}


### PR DESCRIPTION
## Without normal pages
![image](https://user-images.githubusercontent.com/5889006/103881756-2db79d00-50db-11eb-9482-6e79b0e4e853.png)

## With normal pages
![image](https://user-images.githubusercontent.com/5889006/103881783-35774180-50db-11eb-9731-ae9f86b55f96.png)


closes https://github.com/CaiJimmy/hugo-theme-stack/issues/116