### PR TITLE
assets: fix font-family fallback

### DIFF
--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -52,8 +52,8 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
     --sys-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Droid Sans", "Helvetica Neue";
     --zh-font-family: "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei";
 
-    --base-font-family: "Lato", var(--sys-font-family), var(--zh-font-family);
-    --code-font-family: Menlo, Monaco, Consolas, "Courier New";
+    --base-font-family: "Lato", var(--sys-font-family), var(--zh-font-family), sans-serif;
+    --code-font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 /*


### PR DESCRIPTION
If not have `monospace`, fonts will fallback to `sans-serif` when these fonts not available.