### PR TITLE
fix: remove word-wrap property for Safari

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -244,7 +244,6 @@
         padding: 2px 4px;
         border-radius: var(--tag-border-radius);
         font-family: var(--code-font-family);
-        word-wrap: break-word;
     }
 
     .gallery {


### PR DESCRIPTION
Property `word-warp` in selector `.article-content code` wrap content in markdown code block like below **on masOS Safari and all iOS browsers**:

#### `word-wrap: break-word;`
  <img width="500" alt="Screen Shot 2021-01-30 at 22 07 38" src="https://user-images.githubusercontent.com/10704866/106357174-c8f10a80-6347-11eb-9439-491e7b842f0b.png">

#### No `word-wrap: break-word;`
  <img width="500" alt="Screen Shot 2021-01-30 at 22 07 13" src="https://user-images.githubusercontent.com/10704866/106357173-c68eb080-6347-11eb-957f-c6d979f072df.png">

So, I removed this property to make code block the same as with other browsers like Chrome, Firefox, etc.