### PR TITLE
fix(article): also define the padding for div under .article-content

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -189,7 +189,8 @@
     font-size: var(--article-font-size);
     line-height: var(--article-line-height);
 
-    & > p {
+    & > p,
+    & > div {
         margin: 1.5em 0;
         padding: 0 var(--card-padding);
     }


### PR DESCRIPTION
Fixes rstudio/blogdown#591: not only `<p>` but also `<div>` could be the direct child of `.article-content`, so we also need the padding for `<div>`. The `div`s are generated by Pandoc, instead of Hugo's Markdown renderer. I think it will be great to support both ways. Thanks!