### PR TITLE
i18n: German translation

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -11,7 +11,7 @@ disqusShortname: hugo-theme-stack
 googleAnalytics:
 
 # Theme i18n support
-# Available values: en, fr, id, ja, ko, pt-br, zh-cn
+# Available values: en, fr, id, ja, ko, pt-br, zh-cn, de
 DefaultContentLanguage: en
 
 permalinks:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -11,7 +11,7 @@ disqusShortname: hugo-theme-stack
 googleAnalytics:
 
 # Theme i18n support
-# Available values: en, fr, id, ja, ko, pt-br, zh-cn, de
+# Available values: en, fr, id, ja, ko, pt-br, zh-cn, es, de
 DefaultContentLanguage: en
 
 permalinks:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,0 +1,53 @@
+toggleMenu:
+    other: Menü umschalten
+
+darkMode:
+    other: Dunkler Modus
+
+list:
+    page:
+        one: "{{ .Count }} Seite"
+        other: "{{ .Count }} Seiten"
+
+    section:
+        other: Abschnitt
+
+    subsection:
+        one: Unterabschnitt
+        other: Unterabschnitte
+
+article:
+    relatedContents:
+        other: Verwandte Inhalte
+    lastUpdatedOn:
+        other: Zuletzt aktualisiert am
+
+notFound:
+    title:
+        other: Seite nicht gefunden
+    subtitle:
+        other: Diese Seite existiert nicht.
+
+widget:
+    archives:
+        title:
+            other: Archiv
+        more:
+            other: Weitere
+    tagCloud:
+        title:
+            other: Schlagwörter
+
+search:
+    title:
+        other: Suche
+    placeholder:
+        other: Etwas tippen...
+    resultTitle:
+        other: "#PAGES_COUNT pages (#TIME_SECONDS seconds)"
+
+footer:
+    builtWith:
+        other: Erstellt mit {{ .Generator }}
+    designedBy:
+        other: Theme {{ .Theme }} gestaltet von {{ .DesignedBy }}


### PR DESCRIPTION
Added a German translation file and added German and Spanish to the option list in the main config file, as it appears to be missing