### PR TITLE
fix(i18n/ru): Fix warnings after hugo v0.83, add "Back" i18n

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -11,7 +11,7 @@ disqusShortname: hugo-theme-stack
 googleAnalytics:
 
 # Theme i18n support
-# Available values: en, fr, id, ja, ko, pt-br, zh-cn, es, de, nl
+# Available values: en, fr, id, ja, ko, pt-br, zh-cn, es, de, nl, ru
 DefaultContentLanguage: en
 
 permalinks:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -17,6 +17,8 @@ list:
         other: Subsections
 
 article:
+    back:
+        other: Back
     relatedContents:
         other: Related contents
     lastUpdatedOn:

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -1,7 +1,9 @@
 toggleMenu:
+    many: Показать/скрыть меню
     other: Показать/скрыть меню
 
 darkMode:
+    many: Тёмный режим
     other: Тёмный режим
 
 list:
@@ -12,6 +14,7 @@ list:
         other: "{{ .Count }} страниц"
 
     section:
+        many: Раздел
         other: Раздел
 
     subsection:
@@ -21,37 +24,54 @@ list:
         other: Подразделы
 
 article:
+    back:
+        many: Назад
+        other: Назад
     relatedContents:
+        many: Также рекомендуем
         other: Также рекомендуем
     lastUpdatedOn:
+        many: Обновлено
         other: Обновлено
 
 notFound:
     title:
+        many: Не найдено
         other: Не найдено
     subtitle:
+        many: Запрашиваемая страница не существует
         other: Запрашиваемая страница не существует
 
 widget:
     archives:
         title:
+            many: Архивы
             other: Архивы
         more:
+            many: Ещё
             other: Ещё
     tagCloud:
         title:
+            many: Теги
             other: Теги
 
 search:
     title:
+        many: Поиск
         other: Поиск
     placeholder:
+        many: Введите что-нибудь...
         other: Введите что-нибудь...
     resultTitle:
+        one: "Найдено #PAGES_COUNT страница (за #TIME_SECONDS с.)"
+        few: "Найдено #PAGES_COUNT страницы (за #TIME_SECONDS с.)"
+        many: "Найдено #PAGES_COUNT страниц (за #TIME_SECONDS с.)"
         other: "Найдено #PAGES_COUNT страниц (за #TIME_SECONDS с.)"
 
 footer:
     builtWith:
+        many: Создано при помощи {{ .Generator }}
         other: Создано при помощи {{ .Generator }}
     designedBy:
+        many: Тема {{ .Theme }}, дизайн {{ .DesignedBy }}
         other: Тема {{ .Theme }}, дизайн {{ .DesignedBy }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,7 +3,7 @@
     <div id="article-toolbar">
         <a href="{{ .Site.BaseURL }}" class="back-home">
             {{ (resources.Get "icons/back.svg").Content | safeHTML }}
-            <span>Back</span>
+            <span>{{ T "article.back" }}</span>
         </a>
     </div>
 


### PR DESCRIPTION
Fix `Failed to get translated string for language "ru" and ID "...": message "..." has no plural form "many"`
Add i18n for `Back` button (vertical view)