### PR TITLE
feat:add contents .Directory folding

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,49 @@
+<!-- toc.html -->
+<!-- ignore empty links with + -->
+{{ $headers := findRE "<h[1-4].*?>(.|\n])+?</h[1-4]>" .Content }}
+<!-- at least one header to link to -->
+{{ if ge (len $headers) 1 }}
+{{ $h1_n := len (findRE "(.|\n])+?" .Content) }}
+{{ $re := (cond (eq $h1_n 0) "<h[2-4]" "<h[1-4]") }}
+{{ $renum := (cond (eq $h1_n 0) "[2-4]" "[1-4]") }}
+
+<!--Scrollspy-->
+<div class="toc">
+	<!-- Directory folding -->
+	<details>
+		<summary style="height: 49px;">
+			<div class="page-header"><strong style="font-size: 20px;">- Contents -</strong></div>
+		</summary>
+
+		<div id="page-scrollspy" class="toc-nav">
+
+			{{ range $headers }}
+			{{ $header := . }}
+			{{ range first 1 (findRE $re $header 1) }}
+			{{ range findRE $renum . 1 }}
+			{{ $next_heading := (cond (eq $h1_n 0) (sub (int .) 1 ) (int . ) ) }}
+			{{ range seq $next_heading }}
+			<ul class="nav">
+				{{end}}
+				{{ $anchorId := (replaceRE ".* id=\"(.*?)\".*" "$1" $header ) }}
+				<li class="nav-item">
+					<a class="nav-link text-left" href="#{{ $anchorId }}">
+						{{ $header | plainify | htmlUnescape }}
+					</a>
+				</li>
+				<!-- close list -->
+				{{ range seq $next_heading }}
+			</ul>
+			{{ end }}
+			{{ end }}
+			{{ end }}
+			{{ end }}
+
+		</div>
+	</details>
+
+</div>
+
+<!--Scrollspy-->
+
+{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -6,6 +6,11 @@
             <span>Back</span>
         </a>
     </div>
+	
+	<!-- contents -->
+	{{ if .Site.Params.toc | default true }}
+	{{ partial "toc" . }}
+	{{ end }}
 
     {{ partial "article/article.html" . }}
 


### PR DESCRIPTION
**1、Add a directory to the article. The directory can be folded.
2、The table of contents will start with the second level heading.**
![a](https://user-images.githubusercontent.com/60458312/117649677-615a1f00-b1c2-11eb-91ba-4eae8717cd7e.png)
![b](https://user-images.githubusercontent.com/60458312/117649471-235cfb00-b1c2-11eb-936b-3b3b57eecfc3.png)



