### PR TITLE
feat: change horizontal scrollbar styles

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -58,15 +58,15 @@
 
     /* scrollbar styles for Chromium */
     &::-webkit-scrollbar {
-      height: auto;
+        height: auto;
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: var(--scrollbar-thumb);
+        background-color: var(--scrollbar-thumb);
     }
 
     &::-webkit-scrollbar-track {
-      background-color: var(--scrollbar-track);
+        background-color: var(--scrollbar-track);
     }
     /**/
 

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -52,20 +52,11 @@
     margin-bottom: var(--section-separation);
     overflow-x: auto;
 
-    /* scrollbar styles for Firefox */
+    /* Scrollbar styles for Firefox */
     scrollbar-width: thin;
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 
-    /* scrollbar styles for Chromium */
-    &::-webkit-scrollbar {
-      height: 7px;
-      border-radius: 10px;
-    }
-
-    &::-webkit-scrollbar-thumb, &::-webkit-scrollbar-track {
-      border-radius: 10px;
-    }
-
+    /* Scrollbar styles for Chromium */
     &::-webkit-scrollbar-thumb {
       background-color: var(--scrollbar-thumb);
     }

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -52,11 +52,15 @@
     margin-bottom: var(--section-separation);
     overflow-x: auto;
 
-    /* Scrollbar styles for Firefox */
-    scrollbar-width: thin;
+    /* scrollbar styles for Firefox */
+    scrollbar-width: auto;
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 
-    /* Scrollbar styles for Chromium */
+    /* scrollbar styles for Chromium */
+    &::-webkit-scrollbar {
+      height: auto;
+    }
+
     &::-webkit-scrollbar-thumb {
       background-color: var(--scrollbar-thumb);
     }

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -52,6 +52,29 @@
     margin-bottom: var(--section-separation);
     overflow-x: auto;
 
+    /* scrollbar styles for Firefox */
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+
+    /* scrollbar styles for Chromium */
+    &::-webkit-scrollbar {
+      height: 7px;
+      border-radius: 10px;
+    }
+
+    &::-webkit-scrollbar-thumb, &::-webkit-scrollbar-track {
+      border-radius: 10px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--scrollbar-thumb);
+    }
+
+    &::-webkit-scrollbar-track {
+      background-color: var(--scrollbar-track);
+    }
+    /**/
+
     .article-list--tile {
         display: flex;
         padding-bottom: 15px;

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -36,12 +36,17 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     --section-separation: 40px;
 
+    --scrollbar-thumb: hsl(0, 0%, 85%);
+    --scrollbar-track: var(--body-background);
+
     [data-scheme="dark"] {
         --body-background: #303030;
         --accent-color: #ecf0f1;
         --accent-color-darker: #bdc3c7;
         --accent-color-text: #000;
         --body-text-color: rgba(255, 255, 255, 0.7);
+        --scrollbar-thumb: #424242;
+        --scrollbar-track: var(--body-background);
     }
 }
 


### PR DESCRIPTION
Change the horizontal scrollbar styles in Archives page following the dark and light themes styles.  This horizontal scrollbar is at the top of the Archives page. When I visit this page, the scrollbar stole my attention. Unfortunately, it's the client (our browser) who decides its styles;  this change is introduced to avoid that situation.