### PR TITLE
fix(typo): change 'a ex.*' for 'an ex.*'

### DIFF
--- a/exampleSite/content/categories/Test/_index.md
+++ b/exampleSite/content/categories/Test/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Test"
-description: "This is a example category"
+description: "This is an example category"
 slug: "test"
 image: "hutomo-abrianto-l2jk-uxb1BY-unsplash.jpg"
 style:

--- a/layouts/partials/helper/image.html
+++ b/layouts/partials/helper/image.html
@@ -8,7 +8,7 @@
     {{ $url := urls.Parse $imageValue }}
 
     {{ if or (eq $url.Scheme "http") (eq $url.Scheme "https") }}
-        <!-- Is a external image -->
+        <!-- Is an external image -->
         {{ $result = merge $result (dict "permalink" $imageValue) }}
     {{ else }}
         {{ $pageResourceImage := .Context.Resources.GetMatch (printf "%s" ($imageValue | safeURL)) }}


### PR DESCRIPTION
In order to fix this kind of typo, the (not sophisticated) Regular Expression: `[a-zA-Z] [aA] [aeiouAEIOU]` was ran.

That Regular Expression matches some good written sentences like "a User", therefore, those has been omitted.