### PR TITLE
feat: change chroma's horizontal scrollbar styles

### DIFF
--- a/assets/scss/partials/highlight/dark.scss
+++ b/assets/scss/partials/highlight/dark.scss
@@ -6,7 +6,26 @@
 /* Background */
 .chroma {
     color: #f8f8f2;
-    background-color: #272822
+    background-color: #272822;
+
+    /* scrollbar styles for Firefox */
+    scrollbar-width: auto;
+    scrollbar-color: var(--scrollbar-thumb) #272822;
+    /**/
+
+    /* scrollbar styles for Chromium */
+    &::-webkit-scrollbar {
+        height: auto;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: #272822;
+    }
+    /**/
 }
 
 /* Other */

--- a/assets/scss/partials/highlight/light.scss
+++ b/assets/scss/partials/highlight/light.scss
@@ -7,6 +7,25 @@
 .chroma {
     color: #272822;
     background-color: #fafafa;
+
+    /* scrollbar styles for Firefox */
+    scrollbar-width: auto;
+    scrollbar-color: var(--scrollbar-thumb) #fafafa;
+    /**/
+
+    /* scrollbar styles for Chromium */
+    &::-webkit-scrollbar {
+        height: auto;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: #fafafa;
+    }
+    /**/
 }
 
 /* Other */

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -45,7 +45,7 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
         --accent-color-darker: #bdc3c7;
         --accent-color-text: #000;
         --body-text-color: rgba(255, 255, 255, 0.7);
-        --scrollbar-thumb: #424242;
+        --scrollbar-thumb: hsl(0, 0%, 30%);
         --scrollbar-track: var(--body-background);
     }
 }


### PR DESCRIPTION
Again, the chroma's (dark and light) horizontal scrollbar looks pretty awful in Firefox. In order to make them to look consistent in both, Chromium and Firefox, this changed has been introduced.

![aw](https://user-images.githubusercontent.com/68973000/121887312-3476bb80-ccdc-11eb-8bcb-884bd509989f.png)

Now it looks like this:

![wa](https://user-images.githubusercontent.com/68973000/121887456-5c661f00-ccdc-11eb-888e-454fce8abbc2.png)

Dark mode on:

![dw](https://user-images.githubusercontent.com/68973000/121888913-2b86e980-ccde-11eb-9cfe-203181373899.png)

