### PR TITLE
feat: change the page vertical scrollbar styles

### DIFF
--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -1,6 +1,25 @@
 html {
     font-size: 62.5%;
     overflow-y: scroll;
+
+    /* scrollbar styles for Firefox */
+    scrollbar-width: auto;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    /**/
+
+    /* scrollbar styles for Chromium */
+    &::-webkit-scrollbar {
+        height: auto;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: var(--scrollbar-track);
+    }
+    /**/
 }
 
 * {

--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -1,25 +1,6 @@
 html {
     font-size: 62.5%;
     overflow-y: scroll;
-
-    /* scrollbar styles for Firefox */
-    scrollbar-width: auto;
-    scrollbar-color: var(--scrollbar-thumb) transparent;
-    /**/
-
-    /* scrollbar styles for Chromium */
-    &::-webkit-scrollbar {
-        height: auto;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background-color: var(--scrollbar-thumb);
-    }
-
-    &::-webkit-scrollbar-track {
-        background-color: transparent;
-    }
-    /**/
 }
 
 * {
@@ -34,3 +15,24 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
+
+/* scrollbar styles for Firefox */
+* {
+    scrollbar-width: auto;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
+}
+/**/
+
+/* scrollbar styles for Chromium */
+::-webkit-scrollbar {
+    height: auto;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+}
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+/**/

--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -4,7 +4,7 @@ html {
 
     /* scrollbar styles for Firefox */
     scrollbar-width: auto;
-    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    scrollbar-color: var(--scrollbar-thumb) transparent;
     /**/
 
     /* scrollbar styles for Chromium */
@@ -17,7 +17,7 @@ html {
     }
 
     &::-webkit-scrollbar-track {
-        background-color: var(--scrollbar-track);
+        background-color: transparent;
     }
     /**/
 }

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -52,24 +52,6 @@
     margin-bottom: var(--section-separation);
     overflow-x: auto;
 
-    /* scrollbar styles for Firefox */
-    scrollbar-width: auto;
-    scrollbar-color: var(--scrollbar-thumb) transparent;
-
-    /* scrollbar styles for Chromium */
-    &::-webkit-scrollbar {
-        height: auto;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background-color: var(--scrollbar-thumb);
-    }
-
-    &::-webkit-scrollbar-track {
-        background-color: transparent;
-    }
-    /**/
-
     .article-list--tile {
         display: flex;
         padding-bottom: 15px;

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,9 +1,21 @@
 $defaultTagBackgrounds: #8ea885, #df7988, #0177b8, #ffb900, #6b69d6;
 $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
+[data-scheme="light"] {
+    --pre-text-color: #272822;
+    --pre-background-color: #fafafa;
+    @import "partials/highlight/light.scss";
+}
+
+[data-scheme="dark"] {
+    --pre-text-color: #f8f8f2;
+    --pre-background-color: #272822;
+    @import "partials/highlight/dark.scss";
+}
+
 /*
- * Global style
- */
+*   Global style
+*/
 :root {
     @include respond(md) {
         --main-top-padding: 35px;
@@ -26,11 +38,21 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     --scrollbar-thumb: hsl(0, 0%, 85%);
     --scrollbar-track: var(--body-background);
+
+    &[data-scheme="dark"] {
+        --body-background: #303030;
+        --accent-color: #ecf0f1;
+        --accent-color-darker: #bdc3c7;
+        --accent-color-text: #000;
+        --body-text-color: rgba(255, 255, 255, 0.7);
+        --scrollbar-thumb: #424242;
+        --scrollbar-track: var(--body-background);
+    }
 }
 
-/*
- * Global font family
- */
+/**
+*   Global font family
+*/
 :root {
     --sys-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Droid Sans", "Helvetica Neue";
     --zh-font-family: "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei";
@@ -40,8 +62,8 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 }
 
 /*
- * Card style
- */
+*   Card style
+*/
 :root {
     --card-background: #fff;
     --card-background-selected: #eaeaea;
@@ -68,11 +90,20 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
     @include respond(md) {
         --small-card-padding: 25px;
     }
+
+    &[data-scheme="dark"] {
+        --card-background: #424242;
+        --card-background-selected: rgba(255, 255, 255, 0.16);
+        --card-text-color-main: rgba(255, 255, 255, 0.9);
+        --card-text-color-secondary: rgba(255, 255, 255, 0.7);
+        --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
+        --card-separator-color: rgba(255, 255, 255, 0.12);
+    }
 }
 
-/*
- * Article content font settings
- */
+/**
+*   Article content font settings
+*/
 :root {
     --article-font-family: var(--base-font-family);
     --article-font-size: 1.6rem;
@@ -85,8 +116,8 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 }
 
 /*
- * Article content style
- */
+*   Article content style
+*/
 :root {
     --blockquote-border-size: 4px;
     --blockquote-background-color: rgb(248 248 248);
@@ -105,60 +136,26 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     --table-border-color: #dadada;
     --tr-even-background-color: #efefee;
+
+    &[data-scheme="dark"] {
+        --code-background-color: #272822;
+        --code-text-color: rgba(255, 255, 255, 0.9);
+
+        --table-border-color: #717171;
+        --tr-even-background-color: #545454;
+
+        --blockquote-background-color: rgb(75 75 75);
+    }
 }
 
 /*
- * Shadow style
- * Thanks to https://www.figma.com/community/plugin/744987207861965946/Shadow-picker
- */
+*   Shadow style
+*   Thanks to https://www.figma.com/community/plugin/744987207861965946/Shadow-picker
+*/
 :root {
     --shadow-l1: 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 0px 2px rgba(0, 0, 0, 0.06), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l2: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l3: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l4: 0px 24px 32px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04), 0px 4px 8px rgba(0, 0, 0, 0.04),
         0px 0px 1px rgba(0, 0, 0, 0.04);
-}
-
-[data-scheme="light"] {
-    --pre-text-color: #272822;
-    --pre-background-color: #fafafa;
-    @import "partials/highlight/light.scss";
-}
-
-[data-scheme="dark"] {
-    --pre-text-color: #f8f8f2;
-    --pre-background-color: #272822;
-    @import "partials/highlight/dark.scss";
-
-    /* 
-     * Global style 
-     */
-    --body-background: #303030;
-    --accent-color: #ecf0f1;
-    --accent-color-darker: #bdc3c7;
-    --accent-color-text: #000;
-    --body-text-color: rgba(255, 255, 255, 0.7);
-    --scrollbar-thumb: hsl(0, 0%, 30%);
-    --scrollbar-track: var(--body-background);
-
-    /* 
-     * Card style 
-     */
-    --card-background: #424242;
-    --card-background-selected: rgba(255, 255, 255, 0.16);
-    --card-text-color-main: rgba(255, 255, 255, 0.9);
-    --card-text-color-secondary: rgba(255, 255, 255, 0.7);
-    --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
-    --card-separator-color: rgba(255, 255, 255, 0.12);
-
-    /* 
-     * Article content style 
-     */
-    --code-background-color: #272822;
-    --code-text-color: rgba(255, 255, 255, 0.9);
-
-    --table-border-color: #717171;
-    --tr-even-background-color: #545454;
-
-    --blockquote-background-color: rgb(75 75 75);
 }

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,21 +1,9 @@
 $defaultTagBackgrounds: #8ea885, #df7988, #0177b8, #ffb900, #6b69d6;
 $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
-[data-scheme="light"] {
-    --pre-text-color: #272822;
-    --pre-background-color: #fafafa;
-    @import "partials/highlight/light.scss";
-}
-
-[data-scheme="dark"] {
-    --pre-text-color: #f8f8f2;
-    --pre-background-color: #272822;
-    @import "partials/highlight/dark.scss";
-}
-
 /*
-*   Global style
-*/
+ * Global style
+ */
 :root {
     @media (min-width: $on-phone + 1) {
         --main-top-padding: 35px;
@@ -38,21 +26,11 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     --scrollbar-thumb: hsl(0, 0%, 85%);
     --scrollbar-track: var(--body-background);
-
-    [data-scheme="dark"] {
-        --body-background: #303030;
-        --accent-color: #ecf0f1;
-        --accent-color-darker: #bdc3c7;
-        --accent-color-text: #000;
-        --body-text-color: rgba(255, 255, 255, 0.7);
-        --scrollbar-thumb: #424242;
-        --scrollbar-track: var(--body-background);
-    }
 }
 
-/**
-*   Global font family
-*/
+/*
+ * Global font family
+ */
 :root {
     --sys-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Droid Sans", "Helvetica Neue";
     --zh-font-family: "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei";
@@ -62,8 +40,8 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 }
 
 /*
-*   Card style
-*/
+ * Card style
+ */
 :root {
     --card-background: #fff;
     --card-background-selected: #eaeaea;
@@ -87,20 +65,11 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
     @media (max-width: $on-tablet) {
         --small-card-padding: 25px 20px;
     }
-
-    [data-scheme="dark"] {
-        --card-background: #424242;
-        --card-background-selected: rgba(255, 255, 255, 0.16);
-        --card-text-color-main: rgba(255, 255, 255, 0.9);
-        --card-text-color-secondary: rgba(255, 255, 255, 0.7);
-        --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
-        --card-separator-color: rgba(255, 255, 255, 0.12);
-    }
 }
 
-/**
-*   Article content font settings
-*/
+/*
+ * Article content font settings
+ */
 :root {
     --article-font-family: var(--base-font-family);
     --article-font-size: 1.7rem;
@@ -111,8 +80,8 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 }
 
 /*
-*   Article content style
-*/
+ * Article content style
+ */
 :root {
     --blockquote-border-size: 4px;
     --blockquote-background-color: rgb(248 248 248);
@@ -131,26 +100,60 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     --table-border-color: #dadada;
     --tr-even-background-color: #efefee;
-
-    [data-scheme="dark"] {
-        --code-background-color: #272822;
-        --code-text-color: rgba(255, 255, 255, 0.9);
-
-        --table-border-color: #717171;
-        --tr-even-background-color: #545454;
-
-        --blockquote-background-color: rgb(75 75 75);
-    }
 }
 
 /*
-*   Shadow style
-*   Thanks to https://www.figma.com/community/plugin/744987207861965946/Shadow-picker
-*/
+ * Shadow style
+ * Thanks to https://www.figma.com/community/plugin/744987207861965946/Shadow-picker
+ */
 :root {
     --shadow-l1: 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 0px 2px rgba(0, 0, 0, 0.06), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l2: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l3: 0px 10px 20px rgba(0, 0, 0, 0.04), 0px 2px 6px rgba(0, 0, 0, 0.04), 0px 0px 1px rgba(0, 0, 0, 0.04);
     --shadow-l4: 0px 24px 32px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04), 0px 4px 8px rgba(0, 0, 0, 0.04),
         0px 0px 1px rgba(0, 0, 0, 0.04);
+}
+
+[data-scheme="light"] {
+    --pre-text-color: #272822;
+    --pre-background-color: #fafafa;
+    @import "partials/highlight/light.scss";
+}
+
+[data-scheme="dark"] {
+    --pre-text-color: #f8f8f2;
+    --pre-background-color: #272822;
+    @import "partials/highlight/dark.scss";
+
+    /* 
+     * Global style 
+     */
+    --body-background: #303030;
+    --accent-color: #ecf0f1;
+    --accent-color-darker: #bdc3c7;
+    --accent-color-text: #000;
+    --body-text-color: rgba(255, 255, 255, 0.7);
+    --scrollbar-thumb: hsl(0, 0%, 30%);
+    --scrollbar-track: var(--body-background);
+
+    /* 
+     * Card style 
+     */
+    --card-background: #424242;
+    --card-background-selected: rgba(255, 255, 255, 0.16);
+    --card-text-color-main: rgba(255, 255, 255, 0.9);
+    --card-text-color-secondary: rgba(255, 255, 255, 0.7);
+    --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
+    --card-separator-color: rgba(255, 255, 255, 0.12);
+
+    /* 
+     * Article content style 
+     */
+    --code-background-color: #272822;
+    --code-text-color: rgba(255, 255, 255, 0.9);
+
+    --table-border-color: #717171;
+    --tr-even-background-color: #545454;
+
+    --blockquote-background-color: rgb(75 75 75);
 }

--- a/assets/ts/colorScheme.ts
+++ b/assets/ts/colorScheme.ts
@@ -9,7 +9,7 @@ class StackColorScheme {
         this.bindMatchMedia();
         this.currentScheme = this.getSavedScheme();
 
-        this.dispatchEvent(document.body.dataset.scheme as colorScheme);
+        this.dispatchEvent(document.documentElement.dataset.scheme as colorScheme);
 
         if (toggleEl)
             this.bindClick(toggleEl);
@@ -56,13 +56,13 @@ class StackColorScheme {
 
     private setBodyClass() {
         if (this.isDark()) {
-            document.body.dataset.scheme = 'dark';
+            document.documentElement.dataset.scheme = 'dark';
         }
         else {
-            document.body.dataset.scheme = 'light';
+            document.documentElement.dataset.scheme = 'light';
         }
 
-        this.dispatchEvent(document.body.dataset.scheme as colorScheme);
+        this.dispatchEvent(document.documentElement.dataset.scheme as colorScheme);
     }
 
     private getSavedScheme(): colorScheme {

--- a/layouts/partials/comments/provider/remark42.html
+++ b/layouts/partials/comments/provider/remark42.html
@@ -7,7 +7,7 @@
         components: ['embed'],
         url: "{{ $.Permalink }}",
         max_shown_comments: {{ default 15 .max_shown_comments }},
-        theme: document.body.dataset.scheme,
+        theme: document.documentElement.dataset.scheme,
         page_title: '{{ $.Title }}',
         locale: '{{ default "en" .locale }}',
         show_email_subscription: {{ default true .show_email_subscription }}

--- a/layouts/partials/comments/provider/utterances.html
+++ b/layouts/partials/comments/provider/utterances.html
@@ -31,7 +31,7 @@
 
     addEventListener('message', event => {
         if (event.origin !== 'https://utteranc.es') return;
-        setUtterancesTheme(document.body.dataset.scheme)
+        setUtterancesTheme(document.documentElement.dataset.scheme)
     });
 
     window.addEventListener('onColorSchemeChange', (e) => {

--- a/layouts/partials/comments/provider/waline.html
+++ b/layouts/partials/comments/provider/waline.html
@@ -13,7 +13,7 @@
 </style>
 
 {{- with .Site.Params.comments.waline -}}
-{{- $config := dict "el" "#waline" "dark" `body[data-scheme="dark"]` -}}
+{{- $config := dict "el" "#waline" "dark" `html[data-scheme="dark"]` -}}
 {{- $replaceKeys := dict "serverurl" "serverURL" "requiredmeta" "requiredMeta" "wordlimit" "wordLimit" "pagesize" "pageSize" "avatarcdn" "avatarCDN" "avatarforce" "avatarForce" -}}
 
 {{- range $key, $val := . -}}

--- a/layouts/partials/head/colorScheme.html
+++ b/layouts/partials/head/colorScheme.html
@@ -31,9 +31,9 @@
              * 1. If dark mode is set already (in local storage)
              * 2. Auto mode & prefere color scheme is dark
              */
-            document.body.dataset.scheme = 'dark';
+            document.documentElement.dataset.scheme = 'dark';
         } else {
-            document.body.dataset.scheme = 'light';
+            document.documentElement.dataset.scheme = 'light';
         }
     })();
 </script>


### PR DESCRIPTION
This change will make the _vertical_ scrollbar to follow the dark and light style modes. Also, this change will make the _vertical_ scrollbar to look consistent in both, Chromium and Firefox. 

I know we had to set the vertical scrollbar (```html { overflow-y: scroll; ...}```), even when a page doesn't have too much content to need one, to make sure the layout doesn't change when one is switching between pages. For example, in the Search page, when the search form is empty (so it doesn't need a vertical scrollbar because there is no content beyond the vertical viewport), the vertical scrollbar is still there. This change will hide that behavior as well.