### PR TITLE
fix: set the scrollbar-track background to transparent

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -54,7 +54,7 @@
 
     /* scrollbar styles for Firefox */
     scrollbar-width: auto;
-    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    scrollbar-color: var(--scrollbar-thumb) transparent;
 
     /* scrollbar styles for Chromium */
     &::-webkit-scrollbar {
@@ -66,7 +66,7 @@
     }
 
     &::-webkit-scrollbar-track {
-        background-color: var(--scrollbar-track);
+        background-color: transparent;
     }
     /**/
 


### PR DESCRIPTION
The body has this transition: 'transition: background-color 0.3s ease 0s'. Setting the scrollbar-track's background-color of the horizontal scrollbar of the Archives page to transparent, will make us to appreciate that transition when switching the background-color.