### PR TITLE
fix(article): add `white-space: nowrap` to back button text

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -110,6 +110,7 @@
 
         span {
             font-weight: 500;
+            white-space: nowrap;
         }
     }
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/59254886/123429639-1f662a80-d602-11eb-8dbd-d34f989ad87f.png)
![image](https://user-images.githubusercontent.com/59254886/123429494-fd6ca800-d601-11eb-8976-9dbea5ecb7c5.png)
