### PR TITLE
feat(article): use `markdownify` for licence in article

### DIFF
--- a/assets/scss/partials/article.scss
+++ b/assets/scss/partials/article.scss
@@ -137,6 +137,14 @@
     }
 }
 
+.article-footer {
+    .article-copyright {
+        a {
+            color: var(--body-text-color);
+        }
+    }
+}
+
 /* Compact style article list */
 .article-list--compact {
     border-radius: var(--card-border-radius);

--- a/assets/scss/partials/article.scss
+++ b/assets/scss/partials/article.scss
@@ -137,14 +137,6 @@
     }
 }
 
-.article-footer {
-    .article-copyright {
-        a {
-            color: var(--body-text-color);
-        }
-    }
-}
-
 /* Compact style article list */
 .article-list--compact {
     border-radius: var(--card-border-radius);

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -70,6 +70,12 @@
                 flex-wrap: wrap;
                 text-transform: unset;
             }
+
+            .article-copyright {
+                a {
+                    color: var(--body-text-color);
+                }
+            }
         }
     }
 }

--- a/layouts/partials/article/components/footer.html
+++ b/layouts/partials/article/components/footer.html
@@ -4,7 +4,7 @@
     {{ if and (.Site.Params.article.license.enabled) (not (eq .Params.license false)) }}
     <section class="article-copyright">
         {{ partial "helper/icon" "copyright" }}
-        <span>{{ default .Site.Params.article.license.default .Params.license }}</span>
+        <span>{{ default .Site.Params.article.license.default .Params.license | markdownify }}</span>
     </section>
     {{ end }}
 


### PR DESCRIPTION
So we can use links, e.g. to credits for main photo.