### PR TITLE
feat(article): add scrollbar to toc

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -191,8 +191,12 @@
     display: flex;
     flex-direction: column;
     color: var(--card-text-color-main);
+    overflow: hidden;
 
     #TableOfContents {
+        overflow-x: auto;
+        max-height: 75vh;
+
         ol,
         ul {
             margin: 0;


### PR DESCRIPTION
I tried to solve this issue using this PR's approach: https://github.com/CaiJimmy/hugo-theme-stack/pull/247

But it didn't come out well, and the issue has been there for too long.

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/236

The idea is similar to this PR by @zhixuan666: #246. Thanks 👍

`75vh` is just a value that seems to be looking good.