### PR TITLE
refactor(i18n): suggest improvements English translation

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -30,15 +30,15 @@ article:
         other: Last updated on
 
     readingTime:
-        one: "{{ .Count }} min read"
-        ### Seems that there's no need to add 's' even if it's plural in English
-        other: "{{ .Count }} min read"
+        one: "{{ .Count }} minute read"
+        other: "{{ .Count }} minute read"
 
 notFound:
     title:
         other: Not Found
+
     subtitle:
-        other: This page does not exist.
+        other: This page does not exist
 
 widget:
     archives:


### PR DESCRIPTION
I know medium.com does it the same way, but I feel like there is no need to shorten minutes as min for the articles reading time. There is enough horizontal space even on mobile devices and it is easier to read.

Also on most English websites a single short sentence is usually not terminated with a period and IMO it looks nicer without on the 404 page.

Also since you introduced line breaks for all second level YAML objects, there should be one between notFound's second-level objects too.

If you feel otherwise about all this, please feel free to close this PR or to suggest changes, as I can modify the PR or just stick to my fork for my website.

Thanks again for working on this ❤️ 