### PR TITLE
fix(article/comments): accept boolean `true` in `.Params.comments`

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
 
     {{ partial "article/components/related-contents" . }}
      
-    {{ if or (not (isset .Params "comments")) (eq .Params.comments true) (eq .Params.comments "true")}}
+    {{ if not (eq .Params.comments false) }}
         {{ partial "comments/include" . }}
     {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
 
     {{ partial "article/components/related-contents" . }}
      
-    {{ if or (not (isset .Params "comments")) (eq .Params.comments "true")}} 
+    {{ if or (not (isset .Params "comments")) (eq .Params.comments true) (eq .Params.comments "true")}}
         {{ partial "comments/include" . }}
     {{ end }}
 


### PR DESCRIPTION
…as accepting string "true"

It's just simple fix so it's accept a boolean true as well.