### PR TITLE
feat(config): add `hasCJKLanguage` parameter

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -14,6 +14,11 @@ googleAnalytics:
 # Available values: en, fr, id, ja, ko, pt-br, zh-cn, es, de, nl, it
 DefaultContentLanguage: en
 
+# Please set hasCJKLanguage to true if DefaultContentLanguage in [zh-cn ja ko]
+# If true, auto-detect Chinese/Japanese/Korean Languages in the content. 
+# This will make .Summary and .WordCount behave correctly for CJK languages.
+hasCJKLanguage: false
+
 permalinks:
     post: /p/:slug/
     page: /:slug/

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -14,8 +14,7 @@ googleAnalytics:
 # Available values: en, fr, id, ja, ko, pt-br, zh-cn, es, de, nl, it
 DefaultContentLanguage: en
 
-# Please set hasCJKLanguage to true if DefaultContentLanguage in [zh-cn ja ko]
-# If true, auto-detect Chinese/Japanese/Korean Languages in the content. 
+# Set hasCJKLanguage to true if DefaultContentLanguage is in [zh-cn ja ko]
 # This will make .Summary and .WordCount behave correctly for CJK languages.
 hasCJKLanguage: false
 


### PR DESCRIPTION
It is recommended to provide the parameter [hascjklanguage](https://gohugo.io/getting-started/configuration/#hascjklanguage) for users whose native language is Chinese/Japanese/Korean.

When the variable is true, it can make the "reading time" more accurate.