### PR TITLE
feat(comments): add Cusdis support

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -121,6 +121,10 @@ params:
             repo: 
             clientID: 
             clientSecret: 
+        
+        cusdis:
+            host: 
+            id: 
 
     widgets:
         enabled:

--- a/layouts/partials/comments/provider/cusdis.html
+++ b/layouts/partials/comments/provider/cusdis.html
@@ -1,0 +1,24 @@
+<div id="cusdis_thread"
+    {{ if .Site.Params.comments.cusdis.host }}
+    data-host="{{ .Site.Params.comments.cusdis.host }}"
+    {{ else }}
+    data-host="https://cusdis.com"
+    {{ end }}
+    data-app-id="{{ .Site.Params.comments.cusdis.id }}"
+    data-page-id="{{ .File.UniqueID }}"
+    data-page-url="{{ .Permalink }}"
+    data-page-title="{{ .Title }}"></div>
+<script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
+
+<script>
+    function setCusdisTheme(theme) {
+        let cusdis = document.querySelector('#cusdis_thread iframe');
+        if (cusdis) {
+            window.CUSDIS.setTheme(theme)
+        }
+    }
+
+    window.addEventListener('onColorSchemeChange', (e) => {
+        setCusdisTheme(e.detail)
+    })
+</script>


### PR DESCRIPTION
Add [Cusdis](https://cusdis.com/) support.

- [x] Support self-host cusdis
- [x] Support light-dark theme change

Config descriptions are below:

```yaml
cusdis:
    # Self-host address, default to https://cusdis.com
    host: 
    # App id from cusdis
    id: 
```