### PR TITLE
fix(i18n/fr): add missing translations for reading time

### DIFF
--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -29,6 +29,10 @@ article:
     lastUpdatedOn:
         other: Dernière mise à jour le
 
+    readingTime:
+        one: "{{ .Count }} minute de lecture"
+        other: "{{ .Count }} minutes de lecture"
+
 notFound:
     title:
         other: Page non trouvée


### PR DESCRIPTION
Hi,

The translations for reading time was missing for French.
I think there is an issue on full date display (week days and month are still in English) if we change the format (I would like same as [here](https://gohugo.io/content-management/multilingual/#dates)). I'm not yet sure if the issue is in the theme or from my setup.