### PR TITLE
feat(page): allow image_anchor parameter in page frontmatter

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -8,7 +8,7 @@
         <div class="subsection-list">
             <div class="article-list--tile">
                 {{ range $terms }}
-                    {{ partial "article-list/tile" (dict "context" . "size" "250x150" "Type" "taxonomy") }}
+                    {{ partial "article-list/tile" (dict "context" . "size" (printf "250x150 %s" .Params.image_anchor) "Type" "taxonomy") }}
                 {{ end }}
             </div>
         </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -60,7 +60,7 @@
             <div class="subsection-list">
                 <div class="article-list--tile">
                     {{ range . }}
-                        {{ partial "article-list/tile" (dict "context" . "size" "250x150" "Type" "section") }}
+                        {{ partial "article-list/tile" (dict "context" . "size" (printf "250x150 %s" .Params.image_anchor) "Type" "section") }}
                     {{ end }}
                 </div>
             </div>

--- a/layouts/partials/article/components/related-contents.html
+++ b/layouts/partials/article/components/related-contents.html
@@ -5,7 +5,7 @@
     <div class="related-contents">
         <div class="flex article-list--tile">
             {{ range . }}
-                {{ partial "article-list/tile" (dict "context" . "size" "250x150" "Type" "articleList") }}
+                {{ partial "article-list/tile" (dict "context" . "size" (printf "250x150 %s" .Params.image_anchor) "Type" "articleList") }}
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
By default, images are cropped using [Smartcrop](https://gohugo.io/content-management/image-processing/#smart-cropping-of-images), which sometimes gets it wrong.  In those cases, the anchor may be overridden for the feature image in the page frontmatter, e.g.

```
image_anchor = "Center"
```

Permitted values for the anchor are as described in the [Hugo documentation](https://gohugo.io/content-management/image-processing/#anchor).

I didn't find a suitable place to add any documentation about this new feature.