### PR TITLE
feat(article): Scrollspy for the table of contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 public
 resources
 assets/jsconfig.json
+.hugo_build.lock

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -1,10 +1,10 @@
 {
-    "compilerOptions": {
-        "baseUrl": ".",
-        "paths": {
-            "*": [
-                "*"
-            ]
-        },
-    }
+ "compilerOptions": {
+  "baseUrl": ".",
+  "paths": {
+   "*": [
+    "*"
+   ]
+  }
+ }
 }

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -1,10 +1,11 @@
 {
- "compilerOptions": {
-  "baseUrl": ".",
-  "paths": {
-   "*": [
-    "*"
-   ]
-  }
- }
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "*"
+            ]
+        },
+        "target": "es2015"
+    }
 }

--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -1,7 +1,6 @@
 html {
     font-size: 62.5%;
     overflow-y: scroll;
-    scroll-behavior: smooth;
 }
 
 * {

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -122,7 +122,6 @@
 }
 
 .article-page.has-toc {
-    scroll-behavior: smooth;
 
     .left-sidebar {
         display: none;
@@ -193,6 +192,10 @@
     color: var(--card-text-color-main);
     overflow: hidden;
 
+    ::-webkit-scrollbar-thumb {
+        background-color: var(--card-separator-color);
+    }
+
     #TableOfContents {
         overflow-x: auto;
         max-height: 75vh;
@@ -220,7 +223,7 @@
         }
 
         li {
-            margin: 15px 20px;
+            margin: 15px 0 15px 20px;
             padding: 5px;
 
             & > ol,
@@ -233,6 +236,25 @@
                     margin-bottom: 0;
                 }
             }
+        }
+        li.active-class > a {
+            border-left: var(--heading-border-size) solid var(--accent-color);
+            font-weight: bold;
+            display: block;
+        }
+        & > ul > li.active-class > a {
+            margin-left: calc(-25px - 1em);
+            padding-left: calc(25px + 1em - var(--heading-border-size));
+        }
+
+        & > ul > li > ul > li.active-class > a {
+            margin-left: calc(-60px - 1em);
+            padding-left: calc(60px + 1em - var(--heading-border-size));
+        }
+
+        & > ul > li > ul > li > ul > li.active-class > a {
+            margin-left: calc(-95px - 1em);
+            padding-left: calc(95px + 1em - var(--heading-border-size));
         }
     }
 }

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -210,7 +210,7 @@
             list-style-type: none;
             counter-reset: item;
 
-            li:before {
+            li a::before {
                 counter-increment: item;
                 content: counters(item, ".") ". ";
                 font-weight: bold;
@@ -240,21 +240,34 @@
         li.active-class > a {
             border-left: var(--heading-border-size) solid var(--accent-color);
             font-weight: bold;
+        }
+
+        ul li.active-class > a {
             display: block;
         }
-        & > ul > li.active-class > a {
-            margin-left: calc(-25px - 1em);
-            padding-left: calc(25px + 1em - var(--heading-border-size));
+
+        @function repeat($str, $n) {
+            $result: "";
+            @for $_ from 0 to $n {
+                $result: $result + $str;
+            }
+            @return $result;
         }
 
-        & > ul > li > ul > li.active-class > a {
-            margin-left: calc(-60px - 1em);
-            padding-left: calc(60px + 1em - var(--heading-border-size));
-        }
+        // Support up to 6 levels of indentation for lists in ToCs
+        @for $i from 0 to 5 {
+            & > ul #{repeat("> li > ul", $i)} > li.active-class > a {
+                $n: 25 + $i * 35;
+                margin-left: calc(-#{$n}px - 1em);
+                padding-left: calc(#{$n}px + 1em - var(--heading-border-size));
+            }
 
-        & > ul > li > ul > li > ul > li.active-class > a {
-            margin-left: calc(-95px - 1em);
-            padding-left: calc(95px + 1em - var(--heading-border-size));
+            & > ol #{repeat("> li > ol", $i)} > li.active-class > a {
+                $n: 9 + $i * 35;
+                margin-left: calc(-#{$n}px - 1em);
+                padding-left: calc(#{$n}px + 1em - var(--heading-border-size));
+                display: block;
+            }
         }
     }
 }

--- a/assets/ts/main.ts
+++ b/assets/ts/main.ts
@@ -11,6 +11,7 @@ import menu from 'ts/menu';
 import createElement from 'ts/createElement';
 import StackColorScheme from 'ts/colorScheme';
 import { setupScrollspy } from 'ts/scrollspy';
+import { setupSmoothAnchors } from "ts/smoothAnchors";
 
 let Stack = {
     init: () => {
@@ -22,7 +23,8 @@ let Stack = {
         const articleContent = document.querySelector('.article-content') as HTMLElement;
         if (articleContent) {
             new StackGallery(articleContent);
-            setupScrollspy(".article-content h1[id], .article-content h2[id], .article-content h3[id], .article-content h4[id], .article-content h5[id], .article-content h6[id]", "#TableOfContents", "#TableOfContents li", "active-class")
+            setupSmoothAnchors();
+            setupScrollspy();
         }
 
         /**

--- a/assets/ts/main.ts
+++ b/assets/ts/main.ts
@@ -10,6 +10,7 @@ import { getColor } from 'ts/color';
 import menu from 'ts/menu';
 import createElement from 'ts/createElement';
 import StackColorScheme from 'ts/colorScheme';
+import { setupScrollspy } from 'ts/scrollspy';
 
 let Stack = {
     init: () => {
@@ -21,6 +22,7 @@ let Stack = {
         const articleContent = document.querySelector('.article-content') as HTMLElement;
         if (articleContent) {
             new StackGallery(articleContent);
+            setupScrollspy(".article-content h1[id], .article-content h2[id], .article-content h3[id], .article-content h4[id], .article-content h5[id], .article-content h6[id]", "#TableOfContents", "#TableOfContents li", "active-class")
         }
 
         /**

--- a/assets/ts/scrollspy.ts
+++ b/assets/ts/scrollspy.ts
@@ -74,7 +74,6 @@ function setupScrollspy() {
     let activeSectionLink: Element;
 
     function scrollHandler() {
-        console.log("scroll!");
         let scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
 
         let newActiveSection: HTMLElement | undefined;

--- a/assets/ts/scrollspy.ts
+++ b/assets/ts/scrollspy.ts
@@ -1,3 +1,5 @@
+// Implements a scroll spy system for the ToC, displaying the current section with an indicator and scrolling to it when needed.
+
 // While solutions for debouncing like the ones in https://gomakethings.com/debouncing-your-javascript-events/ could work,
 // we do need an actual debouncing of scroll events in order to only capture the "end" of the scroll.
 function debounced(func: Function) {
@@ -17,14 +19,39 @@ function debounced(func: Function) {
     }
 }
 
-function setupScrollspy(headersQuery: string, tocQuery: string, navigationQuery: string, activeClass: string) {
+const headersQuery = ".article-content h1[id], .article-content h2[id], .article-content h3[id], .article-content h4[id], .article-content h5[id], .article-content h6[id]";
+const tocQuery = "#TableOfContents";
+const navigationQuery = "#TableOfContents li";
+const activeClass = "active-class";
+
+function scrollToTocElement(tocElement: HTMLElement, scrollableNavigation: HTMLElement) {
+    let textHeight = tocElement.querySelector("a").offsetHeight;
+    let scrollTop = tocElement.offsetTop - scrollableNavigation.offsetHeight / 2 + textHeight / 2 - scrollableNavigation.offsetTop;
+    if (scrollTop < 0) {
+        scrollTop = 0;
+    }
+    scrollableNavigation.scrollTo({ top: scrollTop, behavior: "smooth" });
+}
+
+function findLinkForSectionId(sectionId: string, navigation: NodeListOf<Element>): HTMLElement | undefined {
+    for (let i = 0; i < navigation.length; i++) {
+        let link = navigation[i].querySelector("a");
+        if (link.getAttribute("href") === "#" + sectionId) {
+            return navigation[i] as HTMLElement;
+        }
+    }
+
+    return undefined;
+}
+
+function setupScrollspy() {
     let headers = document.querySelectorAll(headersQuery);
     if (!headers) {
         console.warn("No header matched query", headers);
         return;
     }
 
-    let scrollableNavigation = document.querySelector(tocQuery);
+    let scrollableNavigation = document.querySelector(tocQuery) as HTMLElement | undefined;
     if (!scrollableNavigation) {
         console.warn("No toc matched query", tocQuery);
         return;
@@ -41,36 +68,37 @@ function setupScrollspy(headersQuery: string, tocQuery: string, navigationQuery:
     headers.forEach((header: HTMLElement) => { sectionsOffsets.push({ id: header.id, offset: header.offsetTop }) });
     sectionsOffsets.sort((a, b) => a.offset - b.offset);
 
-    let activeSectionLink: Element;
+    // We need to avoid scrolling when the user is actively interacting with the ToC. Otherwise, if the user clicks on a link in the ToC,
+    // we would scroll their view, which is not optimal usability-wise.
     let tocHovered: boolean = false;
+    scrollableNavigation.addEventListener("mouseenter", debounced(() => tocHovered = true));
+    scrollableNavigation.addEventListener("mouseleave", debounced(() => tocHovered = false));
 
-    function hoverHandler(isHovered: boolean) {
-        tocHovered = isHovered;
-    }
+    let activeSectionLink: Element;
 
     function scrollHandler(e: Event) {
         let scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
 
-        let newActiveSection: HTMLElement;
+        let newActiveSection: HTMLElement | undefined;
 
+        // Find the section that is currently active.
+        // It is possible for no section to be active, so newActiveSection may be undefined.
         sectionsOffsets.forEach((section) => {
             if (scrollPosition >= section.offset - 20) {
                 newActiveSection = document.getElementById(section.id);
             }
         });
 
-        let newActiveSectionLink: HTMLElement;
+        // Find the link for the active section. Once again, there are a few edge cases:
+        // - No active section = no link => undefined
+        // - No active section but the link does not exist in toc (e.g. because it is outside of the applicable ToC levels) => undefined
+        let newActiveSectionLink: HTMLElement | undefined 
         if (newActiveSection) {
-            for (let i = 0; i < navigation.length; i++) {
-                let link = navigation[i].querySelector("a");
-                if (link.getAttribute("href") === "#" + newActiveSection.id) {
-                    newActiveSectionLink = navigation[i] as HTMLElement;
-                    break;
-                }
-            }
+            newActiveSectionLink = findLinkForSectionId(newActiveSection.id, navigation);
         }
 
         if (newActiveSection && !newActiveSectionLink) {
+            // The active section does not have a link in the ToC, so we can't scroll to it.
             console.warn("No link found for section", newActiveSection);
         } else if (newActiveSectionLink !== activeSectionLink) {
             if (activeSectionLink)
@@ -79,12 +107,7 @@ function setupScrollspy(headersQuery: string, tocQuery: string, navigationQuery:
                 newActiveSectionLink.classList.add(activeClass);
                 if (!tocHovered) {
                     // Scroll so that newActiveSectionLink is in the middle of scrollableNavigation, except when it's from a manual click (hence the tocHovered check)
-                    let textHeight = newActiveSectionLink.querySelector("a").offsetHeight;
-                    let scrollTop = newActiveSectionLink.offsetTop - scrollableNavigation.offsetHeight / 2 + textHeight / 2 - scrollableNavigation.offsetTop;
-                    if (scrollTop < 0) {
-                        scrollTop = 0;
-                    }
-                    scrollableNavigation.scrollTo({ top: scrollTop, behavior: "auto" });
+                    scrollToTocElement(newActiveSectionLink, scrollableNavigation);
                 }
             }
             activeSectionLink = newActiveSectionLink;
@@ -92,8 +115,6 @@ function setupScrollspy(headersQuery: string, tocQuery: string, navigationQuery:
     }
 
     window.addEventListener("scroll", debounced(scrollHandler));
-    scrollableNavigation.addEventListener("mouseenter", debounced(() => hoverHandler(true)));
-    scrollableNavigation.addEventListener("mouseleave", debounced(() => hoverHandler(false)));
 }
 
 export { setupScrollspy };

--- a/assets/ts/scrollspy.ts
+++ b/assets/ts/scrollspy.ts
@@ -1,0 +1,99 @@
+// While solutions for debouncing like the ones in https://gomakethings.com/debouncing-your-javascript-events/ could work,
+// we do need an actual debouncing of scroll events in order to only capture the "end" of the scroll.
+function debounced(func: Function) {
+    let timeout;
+    return (e: Event) => {
+        /*
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = window.requestAnimationFrame(func);
+        */
+        if (timeout) {
+            window.cancelAnimationFrame(timeout);
+        }
+
+        timeout = window.requestAnimationFrame(() => func(e));
+    }
+}
+
+function setupScrollspy(headersQuery: string, tocQuery: string, navigationQuery: string, activeClass: string) {
+    let headers = document.querySelectorAll(headersQuery);
+    if (!headers) {
+        console.warn("No header matched query", headers);
+        return;
+    }
+
+    let scrollableNavigation = document.querySelector(tocQuery);
+    if (!scrollableNavigation) {
+        console.warn("No toc matched query", tocQuery);
+        return;
+    }
+
+    let navigation = document.querySelectorAll(navigationQuery);
+    if (!navigation) {
+        console.warn("No navigation matched query", navigationQuery);
+        return;
+    }
+
+    let sectionsOffsets = [];
+
+    headers.forEach((header: HTMLElement) => { sectionsOffsets.push({ id: header.id, offset: header.offsetTop }) });
+    sectionsOffsets.sort((a, b) => a.offset - b.offset);
+
+    let activeSectionLink: Element;
+    let tocHovered: boolean = false;
+
+    function hoverHandler(isHovered: boolean) {
+        tocHovered = isHovered;
+    }
+
+    function scrollHandler(e: Event) {
+        let scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
+
+        let newActiveSection: HTMLElement;
+
+        sectionsOffsets.forEach((section) => {
+            if (scrollPosition >= section.offset - 20) {
+                newActiveSection = document.getElementById(section.id);
+            }
+        });
+
+        let newActiveSectionLink: HTMLElement;
+        if (newActiveSection) {
+            for (let i = 0; i < navigation.length; i++) {
+                let link = navigation[i].querySelector("a");
+                if (link.getAttribute("href") === "#" + newActiveSection.id) {
+                    newActiveSectionLink = navigation[i] as HTMLElement;
+                    break;
+                }
+            }
+        }
+
+        if (newActiveSection && !newActiveSectionLink) {
+            console.warn("No link found for section", newActiveSection);
+        } else if (newActiveSectionLink !== activeSectionLink) {
+            if (activeSectionLink)
+                activeSectionLink.classList.remove(activeClass);
+            if (newActiveSectionLink) {
+                newActiveSectionLink.classList.add(activeClass);
+                if (!tocHovered) {
+                    // Scroll so that newActiveSectionLink is in the middle of scrollableNavigation, except when it's from a manual click (hence the tocHovered check)
+                    let textHeight = newActiveSectionLink.querySelector("a").offsetHeight;
+                    let scrollTop = newActiveSectionLink.offsetTop - scrollableNavigation.offsetHeight / 2 + textHeight / 2 - scrollableNavigation.offsetTop;
+                    if (scrollTop < 0) {
+                        scrollTop = 0;
+                    }
+                    scrollableNavigation.scrollTo({ top: scrollTop, behavior: "auto" });
+                }
+            }
+            activeSectionLink = newActiveSectionLink;
+        }
+    }
+
+    window.addEventListener("scroll", debounced(scrollHandler));
+    scrollableNavigation.addEventListener("mouseenter", debounced(() => hoverHandler(true)));
+    scrollableNavigation.addEventListener("mouseleave", debounced(() => hoverHandler(false)));
+}
+
+export { setupScrollspy };

--- a/assets/ts/smoothAnchors.ts
+++ b/assets/ts/smoothAnchors.ts
@@ -1,0 +1,30 @@
+// Implements smooth scrolling when clicking on an anchor link.
+// This is required instead of using modern CSS because Chromium does not currently support scrolling
+// one element with scrollTo while another element is scrolled because of a click on a link. This would thus not work with the ToC scrollspy.
+
+const anchorLinksQuery = "a[href]";
+
+function setupSmoothAnchors() {
+    document.querySelectorAll(anchorLinksQuery).forEach(aElement => {
+        let href = aElement.getAttribute("href");
+        if (!href.startsWith("#")) {
+            return;
+        }
+        aElement.addEventListener("click", clickEvent => {
+            clickEvent.preventDefault();
+
+            let targetId = aElement.getAttribute("href").substring(1);
+            let target = document.querySelector(`#${targetId.replace(":", "\\:")}`) as HTMLElement;
+            
+            //let tocLink = findLinkForSectionId(targetId, navigation);
+            //if (tocLink) {
+            //    scrollToTocElement(tocLink, scrollableNavigation);
+            //}
+
+            window.history.pushState({}, "", aElement.getAttribute("href"));
+            scrollTo({ top: target.offsetTop, behavior: "smooth" });
+        });
+    });
+}
+
+export { setupSmoothAnchors };

--- a/assets/ts/smoothAnchors.ts
+++ b/assets/ts/smoothAnchors.ts
@@ -1,6 +1,14 @@
 // Implements smooth scrolling when clicking on an anchor link.
 // This is required instead of using modern CSS because Chromium does not currently support scrolling
-// one element with scrollTo while another element is scrolled because of a click on a link. This would thus not work with the ToC scrollspy.
+// one element with scrollTo while another element is scrolled because of a click on a link. This would
+// thus not work with the ToC scrollspy and e.g. footnotes.
+
+// Here are additional links about this issue:
+// - https://stackoverflow.com/questions/49318497/google-chrome-simultaneously-smooth-scrollintoview-with-more-elements-doesn
+// - https://stackoverflow.com/questions/57214373/scrollintoview-using-smooth-function-on-multiple-elements-in-chrome
+// - https://bugs.chromium.org/p/chromium/issues/detail?id=833617
+// - https://bugs.chromium.org/p/chromium/issues/detail?id=1043933
+// - https://bugs.chromium.org/p/chromium/issues/detail?id=1121151
 
 const anchorLinksQuery = "a[href]";
 
@@ -14,12 +22,8 @@ function setupSmoothAnchors() {
             clickEvent.preventDefault();
 
             let targetId = aElement.getAttribute("href").substring(1);
+            // The replace done on ':' is here for footnotes, as this character would otherwise interfere when used as a CSS selector.
             let target = document.querySelector(`#${targetId.replace(":", "\\:")}`) as HTMLElement;
-            
-            //let tocLink = findLinkForSectionId(targetId, navigation);
-            //if (tocLink) {
-            //    scrollToTocElement(tocLink, scrollableNavigation);
-            //}
 
             window.history.pushState({}, "", aElement.getAttribute("href"));
             scrollTo({ top: target.offsetTop, behavior: "smooth" });


### PR DESCRIPTION
A bunch of things in this PR. I'll go ahead and say right away: feel free to *not* merge this if you don't feel like this is a good change. This is something I wanted to make for my own website, and I felt like it might be a good idea to upstream these changes.

**Changes:**

- Added the Hugo build lock file to the gitignore. This is a [file added by new Hugo versions that needs to be gitignore'd](https://gohugo.io/news/0.89.0-relnotes/#notes)
- Added ES2015 as the target in `jsconfig.json`. VS Code was reporting issues from existing TS code because this was not set.
- Removed the existing `scroll-behavior: smooth` and use a custom smoothing system (`smoothAnchors.ts`). This is required because Chromium does not support smooth scrolling on both the main page via an `a` link and on another element via a `scrollTo()` call.
- Added a CSS rule for the scrollbar thumb in the table of contents. There was actually one before, but it was the same color as the background, making it invisible. This is now fixed.
- Added a scroll spy system that displays the currently viewed section within the table of contents and automatically scrolls to display said section.

Here's an example of it in action:

https://user-images.githubusercontent.com/5175705/143720393-22946e89-ed30-4e4c-ab6b-b1db34d741b5.mp4




**TODO:**

- [x] Offset for each section needs to be recomputed when the window size changes
- [x] Video demo
- [x] Support `ol` and not just `ul`. ~~Seems that the approach I have used styling-wise does not work with the custom `ol` elements being used.~~ Actually works fine but required a modification on how ordered lists work in ToCs