### PR TITLE
“subtitle” Support for HTML syntax

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -31,7 +31,7 @@
         {{ end }}
         
         <h1 class="site-name"><a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Title }}</a></h1>
-        <h2 class="site-description">{{ .Site.Params.sidebar.subtitle }}</h2>
+        <h2 class="site-description">{{ .Site.Params.sidebar.subtitle | safeHTML }}</h2>
 
         {{- with .Site.Menus.social -}}
             <ol class="social-menu">


### PR DESCRIPTION
Support for HTML syntax to avoid escaping by Go templates.
For example :
![img](https://user-images.githubusercontent.com/21136361/145946560-8e649c76-cfa1-44fe-bdff-3979e7fad9f7.png)
