### PR TITLE
feat: turn stack theme into a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ It's necessary to use **Hugo Extended ≥ 0.87.0**.
 
 ## Installation
 
-Clone / Download this repository to `theme` folder, and edit your site config following `exampleSite/config.yaml`.
+* Route 1: Clone / Download this repository to `theme` folder
+* Route 2: Turn your site into a hugo module and add this theme as a module dependency
+
+ Edit your site config following `exampleSite/config.yaml`.
 
 *Note: Remove `config.toml` if there is one in the site folder.*
 

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,3 +1,0 @@
-module github.com/CaiJimmy/hugo-theme-stack/exampleSite
-
-go 1.12

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,3 @@
+module github.com/CaiJimmy/hugo-theme-stack/exampleSite
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/CaiJimmy/hugo-theme-stack
+
+go 1.12


### PR DESCRIPTION
This PR turns the theme into a hugo module.
With `git`and `go` installed, making use of the `stack` theme is now as easy as:

```
hugo new site my_site
cd mysite
echo 'theme: "github.com/CaiJimmy/hugo-theme-stack-example"' >> config.yaml
hugo server
```

Copying/cloning the theme in the themes folder is still possible of course.

In combination with this PR I authored another [pull request](https://github.com/CaiJimmy/stack-docs/pull/9) on the `stackdocs` repo which extends the `installation` section of your documentation, explaining how to make use of the theme as module.