### PR TITLE
fix: disqus dark mode

### DIFF
--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -22,3 +22,17 @@ body {
     scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 /**/
+
+/* scrollbar styles for Chromium */
+::-webkit-scrollbar {
+    height: auto;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+}
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+/**/

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -12,6 +12,10 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
     --pre-text-color: #f8f8f2;
     --pre-background-color: #272822;
     @import "partials/highlight/dark.scss";
+
+    iframe {
+        color-scheme: dark;
+    }
 }
 
 /*

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -8,14 +8,9 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 }
 
 [data-scheme="dark"] {
-    color-scheme: dark;
     --pre-text-color: #f8f8f2;
     --pre-background-color: #272822;
     @import "partials/highlight/dark.scss";
-
-    iframe {
-        color-scheme: dark;
-    }
 }
 
 /*
@@ -50,7 +45,7 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
         --accent-color-darker: #bdc3c7;
         --accent-color-text: #000;
         --body-text-color: rgba(255, 255, 255, 0.7);
-        --scrollbar-thumb: #424242;
+        --scrollbar-thumb: hsl(0, 0%, 40%);
         --scrollbar-track: var(--body-background);
     }
 }


### PR DESCRIPTION
closes #474 

Removed CSS `color-scheme` property, which is introduced in #428 as fix for invisible table scrollbar. 
I changed scrollbar color to avoid that problem.