### PR TITLE
fix(article): .highlight can't change to light

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -395,7 +395,7 @@
     }
 
     .highlight {
-        background-color: var(--pre-background-color);
+        background-color: var(--card-background);
         padding: var(--card-padding);
         position: relative;
 


### PR DESCRIPTION
fixed the issue: .highlight for code blocks stays dark and won't change to the light theme