### PR TITLE
fix(RSS): page context selection

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -6,12 +6,10 @@
 {{- else -}}
 {{- $pages = $pctx.Pages -}}
 {{- end -}}
-{{- $pages := where $pages "Type" "in" .Site.Params.mainSections -}}
-{{- $notHidden := where $pages "Params.hidden" "!=" true -}}
-{{- $filtered := ($pages | intersect $notHidden) -}}
+{{- $pages := where $pages "Params.hidden" "!=" true -}}
 {{- $limit := .Site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}
-{{- $filtered = $filtered | first $limit -}}
+{{- $pages = $pages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
@@ -28,7 +26,7 @@
         {{- with .OutputFormats.Get "RSS" -}}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
         {{- end -}}
-        {{ range $filtered }}
+        {{ range $pages }}
         {{- $content := safeHTML (.Summary | html) -}}
         {{- if .Site.Params.rssFullContent -}}
             {{- $content = safeHTML (.Content | html) -}}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,5 +1,13 @@
-{{- $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections -}}
-{{- $notHidden := where .Site.RegularPages "Params.hidden" "!=" true -}}
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $pages := where $pages "Type" "in" .Site.Params.mainSections -}}
+{{- $notHidden := where $pages "Params.hidden" "!=" true -}}
 {{- $filtered := ($pages | intersect $notHidden) -}}
 {{- $limit := .Site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}


### PR DESCRIPTION
Sorry, I didn't check the result in #514.
After change in #514, all posts show in feed.
https://demo.stack.jimmycai.com/categories/syntax/index.xml
I checkout [rss.xml template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml#L1-L8) to fix this problem.
I don't sure `.Site.Params.mainSections` need `$pctx` or not.