### PR TITLE
feat: add `general.scss` and change link hover style

### DIFF
--- a/assets/scss/general.scss
+++ b/assets/scss/general.scss
@@ -11,7 +11,7 @@ a {
         transition: all 0.3s ease;
 
         &:hover {
-            box-shadow: 0px calc(-1rem*var(--article-line-height)) 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
+            box-shadow: 0px calc(-1rem * var(--article-line-height)) 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
         }
     }
 }

--- a/assets/scss/general.scss
+++ b/assets/scss/general.scss
@@ -11,7 +11,7 @@ a {
         transition: all 0.3s ease;
 
         &:hover {
-            box-shadow: 0px -10px 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
+            box-shadow: 0px calc(-1rem*var(--article-line-height)) 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
         }
     }
 }

--- a/assets/scss/general.scss
+++ b/assets/scss/general.scss
@@ -1,0 +1,31 @@
+a {
+    text-decoration: none;
+    color: var(--accent-color);
+
+    &:hover {
+        color: var(--accent-color-darker);
+    }
+
+    &.link {
+        box-shadow: 0px -2px 0px rgba(var(--link-background-color), var(--link-background-opacity)) inset;
+        transition: all 0.3s ease;
+
+        &:hover {
+            box-shadow: 0px -10px 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
+        }
+    }
+}
+
+.section-title {
+    text-transform: uppercase;
+    margin-top: 0;
+    margin-bottom: 10px;
+    display: block;
+    font-size: 1.6rem;
+    font-weight: bold;
+    color: var(--body-text-color);
+
+    a {
+        color: var(--body-text-color);
+    }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -24,36 +24,5 @@
 @import "partials/layout/404.scss";
 @import "partials/layout/search.scss";
 
+@import "general.scss";
 @import "custom.scss";
-
-a {
-    text-decoration: none;
-    color: var(--accent-color);
-
-    &:hover {
-        color: var(--accent-color-darker);
-    }
-
-    &.link {
-        box-shadow: 0px -2px 0px rgba(var(--link-background-color), var(--link-background-opacity)) inset;
-        transition: all 0.3s ease;
-
-        &:hover {
-            box-shadow: 0px -10px 0px rgba(var(--link-background-color), var(--link-background-opacity-hover)) inset;
-        }
-    }
-}
-
-.section-title {
-    text-transform: uppercase;
-    margin-top: 0;
-    margin-bottom: 10px;
-    display: block;
-    font-size: 1.6rem;
-    font-weight: bold;
-    color: var(--body-text-color);
-
-    a {
-        color: var(--body-text-color);
-    }
-}


### PR DESCRIPTION
- Move styles to general.scss, and alllow custom.scss to overwrite all style.
- Change link hover box-shadow height
    from <img width="117" alt="image" src="https://user-images.githubusercontent.com/14134195/157755482-21172a34-7c36-405a-992a-fa5bd9a7f75c.png"> to <img width="121" alt="image" src="https://user-images.githubusercontent.com/14134195/157754922-d9022a8c-36a7-4a7e-94ce-1e996de2685a.png">
