### PR TITLE
refactor: rename "Related contents" to "Related content"

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -166,7 +166,7 @@
     }
 }
 
-.related-contents {
+.related-content {
     overflow-x: auto;
     padding-bottom: 15px;
 

--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: جدول المحتويات
 
-    relatedContents:
+    relatedContent:
         other: محتوى مشابهه
         
     lastUpdatedOn:

--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Taula de contingut
 
-    relatedContents:
+    relatedContent:
         other: Continguts relacionats
 
     lastUpdatedOn:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Inhaltsverzeichnis
 
-    relatedContents:
+    relatedContent:
         other: Verwandte Inhalte
 
     lastUpdatedOn:

--- a/i18n/el.yaml
+++ b/i18n/el.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Πινακας περιεχομενων
 
-    relatedContents:
+    relatedContent:
         other: Σχετικο περιεχομενο
 
     lastUpdatedOn:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -23,8 +23,8 @@ article:
     tableOfContents:
         other: Table of contents
 
-    relatedContents:
-        other: Related contents
+    relatedContent:
+        other: Related content
 
     lastUpdatedOn:
         other: Last updated on

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Tabla de contenido
 
-    relatedContents:
+    relatedContent:
         other: Contenidos relacionados
 
     lastUpdatedOn:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Table des matières
 
-    relatedContents:
+    relatedContent:
         other: Contenus liés
 
     lastUpdatedOn:

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Daftar Isi
 
-    relatedContents:
+    relatedContent:
         other: Konten terkait
 
     lastUpdatedOn:

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Indice
 
-    relatedContents:
+    relatedContent:
         other: Contenuti correlati
 
     lastUpdatedOn:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -11,7 +11,7 @@ article:
     tableOfContents:
         other: 目次
 
-    relatedContents:
+    relatedContent:
         other: 関連するコンテンツ
 
     lastUpdatedOn:

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: 목차
         
-    relatedContents:
+    relatedContent:
         other: 관련 글
         
     lastUpdatedOn:

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -17,7 +17,7 @@ list:
         other: Subsecties
 
 article:
-    relatedContents:
+    relatedContent:
         other: Gerelateerde inhoud
     lastUpdatedOn:
         other: Laatst bijgewerkt op

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Spis treści
 
-    relatedContents:
+    relatedContent:
         other: Powiązane artykuły
 
     lastUpdatedOn:

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: Índice
 
-    relatedContents:
+    relatedContent:
         other: Conteúdo relacionado
 
     lastUpdatedOn:

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -23,7 +23,7 @@ list:
 article:
     back:
         other: Назад
-    relatedContents:
+    relatedContent:
         other: Также рекомендуем
     lastUpdatedOn:
         other: Обновлено

--- a/i18n/th.yaml
+++ b/i18n/th.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: สารบัญ
 
-    relatedContents:
+    relatedContent:
         other: เนื้อหาคล้ายคลึงกัน
 
     lastUpdatedOn:

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -17,7 +17,7 @@ list:
         other: Alt bölümler
 
 article:
-    relatedContents:
+    relatedContent:
         other: Alakalı içerikler
     lastUpdatedOn:
         other: Son güncelleme

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -24,7 +24,7 @@ article:
     tableOfContents:
         other: Зміст
 
-    relatedContents:
+    relatedContent:
         other: Схожі матеріали
 
     lastUpdatedOn:

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -11,7 +11,7 @@ article:
     tableOfContents:
         other: 目录
 
-    relatedContents:
+    relatedContent:
         other: 相关文章
 
     lastUpdatedOn:

--- a/i18n/zh-hk.yaml
+++ b/i18n/zh-hk.yaml
@@ -23,7 +23,7 @@ article:
     tableOfContents:
         other: 目錄
 
-    relatedContents:
+    relatedContent:
         other: 相關內容
 
     lastUpdatedOn:

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -11,7 +11,7 @@ article:
     tableOfContents:
         other: 目錄
 
-    relatedContents:
+    relatedContent:
         other: 相關文章
 
     lastUpdatedOn:

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,7 +30,7 @@
         {{ partial "article/components/links" . }}
     {{ end }}
 
-    {{ partial "article/components/related-contents" . }}
+    {{ partial "article/components/related-content" . }}
      
     {{ if not (eq .Params.comments false) }}
         {{ partial "comments/include" . }}

--- a/layouts/partials/article/components/related-content.html
+++ b/layouts/partials/article/components/related-content.html
@@ -1,8 +1,8 @@
 {{ $related := (where (.Site.RegularPages.Related .) "Params.hidden" "!=" true) | first 5 }}
 {{ with $related }}
-<aside class="related-contents--wrapper">
-    <h2 class="section-title">{{ T "article.relatedContents" }}</h2>
-    <div class="related-contents">
+<aside class="related-content--wrapper">
+    <h2 class="section-title">{{ T "article.relatedContent" }}</h2>
+    <div class="related-content">
         <div class="flex article-list--tile">
             {{ range . }}
                 {{ partial "article-list/tile" (dict "context" . "size" "250x150" "Type" "articleList") }}


### PR DESCRIPTION
The RELATED CONTENTS text should be RELATED CONTENT.

![Screen Shot 2022-03-09 at 10 21 38 PM](https://user-images.githubusercontent.com/25377399/157601627-2a7c076a-f617-482d-8de9-fa0e9a40338e.png)

This is a grammar fix.

> Clone of #549