### PR TITLE
Add rel="apple-touch-icon" to use favicon as iOS home screen icon

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -18,7 +18,8 @@
 {{- end -}}
 
 {{ with .Site.Params.favicon }}
-    <link rel="shortcut icon" href="{{ . }}" />
+    <link rel="shortcut icon" href="{{ . }}" >
+    <link rel="apple-touch-icon" href="{{ . }}"/>
 {{ end }}
 
 {{- template "_internal/google_analytics.html" . -}}


### PR DESCRIPTION
Add rel="apple-touch-icon" to use favicon as iOS home screen icon