### PR TITLE
fix(article): TOC link not working when the heading starts with digits

### DIFF
--- a/assets/ts/smoothAnchors.ts
+++ b/assets/ts/smoothAnchors.ts
@@ -23,7 +23,7 @@ function setupSmoothAnchors() {
 
             let targetId = aElement.getAttribute("href").substring(1);
             // The replace done on ':' is here for footnotes, as this character would otherwise interfere when used as a CSS selector.
-            let target = document.querySelector(`#${targetId.replace(":", "\\:")}`) as HTMLElement;
+            let target = document.getElementById(targetId.replace(":", "\\:")) as HTMLElement;
 
             window.history.pushState({}, "", aElement.getAttribute("href"));
             scrollTo({ top: target.offsetTop, behavior: "smooth" });


### PR DESCRIPTION
当文章目录为数字开头时，querySelector 无法正确选择到对应的元素。

替换为 getElementById 时能够解决此问题。