### PR TITLE
feat: make header of sidebar centered

### DIFF
--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -213,7 +213,7 @@
 .social-menu {
     list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 0 auto;
     display: flex;
     flex-direction: row;
     gap: 10px;

--- a/assets/scss/partials/sidebar.scss
+++ b/assets/scss/partials/sidebar.scss
@@ -95,7 +95,7 @@
 
     .site-avatar {
         position: relative;
-        margin: 0;
+        margin: 0 auto;
         width: var(--sidebar-avatar-size);
         height: var(--sidebar-avatar-size);
         flex-shrink: 0;
@@ -131,7 +131,7 @@
 
     .site-name {
         color: var(--accent-color);
-        margin: 0;
+        margin: 0 auto;
         font-size: 1.6rem;
 
         @include respond(2xl) {
@@ -142,7 +142,8 @@
     .site-description {
         color: var(--body-text-color);
         font-weight: normal;
-        margin: 0;
+        margin: 0 auto;
+        text-align: center;
         font-size: 1.4rem;
 
         @include respond(2xl) {


### PR DESCRIPTION
- on mobile view
![hugo-stack-0](https://user-images.githubusercontent.com/9915368/170822805-15d38df5-a096-4474-8d3d-3a60810eccf8.png)

- on desktop view
![hugo-stack-1](https://user-images.githubusercontent.com/9915368/170823492-2b34b9fb-24c4-41f1-895a-200dc577b7ec.png)

If not merged in time, theme users can use code change for their own site config:
1. cd site dir
2. `cp -r themes/hugo-theme-stack/assets .`
3. edite **site-dir/assets/scss/partials/menu.scss** and **site-dir/assets/scss/partials/sidebar.scss**, change scss as this pr
4. run `hugo server` and open localhost:1313 to see updated

above config refer [theme stack docs-modify theme](https://docs.stack.jimmycai.com/zh/modify-theme/)