### PR TITLE
feat(article): GitLab Snippets Shortcode

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -387,6 +387,18 @@
         }
     }
 
+    .gitlab-embed-snippets {
+        margin: 0 !important;
+
+        .file-holder.snippet-file-content {
+          margin-block-end: 0 !important;
+          margin-block-start: 0 !important;
+          margin-left: calc((var(--card-padding)) * -1) !important;
+          margin-right: calc((var(--card-padding)) * -1) !important;
+          padding: 0 var(--card-padding) !important;
+        }
+    }
+
     /// Negative margins
     blockquote,
     figure,

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -391,11 +391,11 @@
         margin: 0 !important;
 
         .file-holder.snippet-file-content {
-          margin-block-end: 0 !important;
-          margin-block-start: 0 !important;
-          margin-left: calc((var(--card-padding)) * -1) !important;
-          margin-right: calc((var(--card-padding)) * -1) !important;
-          padding: 0 var(--card-padding) !important;
+            margin-block-end: 0 !important;
+            margin-block-start: 0 !important;
+            margin-left: calc((var(--card-padding)) * -1) !important;
+            margin-right: calc((var(--card-padding)) * -1) !important;
+            padding: 0 var(--card-padding) !important;
         }
     }
 

--- a/exampleSite/content/post/rich-content/index.md
+++ b/exampleSite/content/post/rich-content/index.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 
@@ -40,6 +40,10 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 ## Gist Shortcode
 
 {{< gist spf13 7896402 >}}
+
+## Gitlab Snippets Shortcode
+
+{{< gitlab 2349278 >}}
 
 ## Quote Shortcode
 

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -1,4 +1,4 @@
 <script
-  type="application/javascript"
-  src="https://gitlab.com/-/snippets/{{ index .Params 0 }}.js"
+    type="application/javascript"
+    src="https://gitlab.com/-/snippets/{{ index .Params 0 }}.js"
 ></script>

--- a/layouts/shortcodes/gitlab.html
+++ b/layouts/shortcodes/gitlab.html
@@ -1,0 +1,4 @@
+<script
+  type="application/javascript"
+  src="https://gitlab.com/-/snippets/{{ index .Params 0 }}.js"
+></script>


### PR DESCRIPTION
Add GitLab Snippets Shortcode #577

![Screenshot_6-edited](https://user-images.githubusercontent.com/23427492/173176733-c567fd81-8f40-4a33-8c79-218047ecb33f.png)

Also edit `twitter_simple` shortcode. The `twitter_simple` shortcode will soon require two named parameters: `user` and `id`.