### PR TITLE
fix: incorrect if statement in `imageProcessing.cover.enabled`

### DIFF
--- a/layouts/partials/article-list/tile.html
+++ b/layouts/partials/article-list/tile.html
@@ -10,7 +10,7 @@
                     {{- $Width := $imageRaw.Width -}}
                     {{- $Height := $imageRaw.Height -}}
 
-                    {{- if .context.Site.Params.imageProcessing.cover.enabled -}}
+                    {{- if eq .context.Site.Params.imageProcessing.cover.enabled true -}}
                         {{- $thumbnail := $imageRaw.Fill .size -}}
                         {{- $Permalink = $thumbnail.RelPermalink -}}
                         {{- $Width = $thumbnail.Width -}}


### PR DESCRIPTION
The incorrect `.context.Site.Params.imageProcessing.cover.enabled` if statement will make Hugo still process the image, even if the `.Site.Params.imageProcessing.cover.enabled` has been set to `false`.

So, the equal condition is needed to ensure that option is truly enabled.