### PR TITLE
feat(article): develop blockquote style

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -230,10 +230,11 @@
     }
 
     blockquote {
+        color: #777777;
         position: relative;
         margin: 1.5em 0;
         border-inline-start: var(--blockquote-border-size) solid var(--card-separator-color);
-        padding: 15px calc(var(--card-padding) - var(--blockquote-border-size));
+        padding-left: calc(var(--card-padding) - var(--blockquote-border-size));
         background-color: var(--blockquote-background-color);
 
         .cite {
@@ -244,6 +245,10 @@
             a {
                 text-decoration: underline;
             }
+        }
+
+        .p {
+          padding-left: 5px;
         }
     }
 

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -105,8 +105,7 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 *   Article content style
 */
 :root {
-    --blockquote-border-size: 4px;
-    --blockquote-background-color: rgb(248 248 248);
+    --blockquote-border-size: 10px;
 
     --heading-border-size: 4px;
 


### PR DESCRIPTION
The previous text color is the same as the main body text color, which is not very pretty,
Improved the following:
    blockquote-text-color,
    blockquote-border-size,
    blockquote-padding,
    blockquote-background-color