### PR TITLE
feat: add a separate configuration field for site description

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -8,15 +8,18 @@ languages:
     en:
         languageName: English
         title: Example Site
+        description: Example description
         weight: 1
     zh-cn:
         languageName: 中文
         title: 演示站点
+        description: 演示说明
         weight: 2
     ar:
         languageName: عربي
         languagedirection: rtl
         title: موقع تجريبي
+        description: وصف تجريبي
         weight: 3
 
 # Change it to your Disqus shortname before using

--- a/layouts/partials/data/description.html
+++ b/layouts/partials/data/description.html
@@ -1,6 +1,11 @@
 <!-- Use site subtitle by default -->
 {{ $description := .Site.Params.sidebar.subtitle }}
 
+<!-- Seprate description exists -->
+{{ if .Site.Params.description }}
+    {{ $description = .Site.Params.description }}
+{{ end }}
+
 {{ if .Description }}
     <!-- Page description exists -->
     {{ $description = .Description }}


### PR DESCRIPTION
This a non-breaking feature PR.

It just adds a new option to set a meta description for the website, separate from the sidebar subtitle.

The default behavior won't change, it will still fallback to the sidebar's subtitle.