### PR TITLE
feat(article): add `readingTime` front matter field to overwrite global configuration

### DIFF
--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -34,7 +34,7 @@
             </div>
         {{ end }}
 
-        {{ if .Site.Params.article.readingTime }}
+    {{ if and (not (.Params.DisableReadTime | default false)) (.Site.Params.article.readingTime)}}
             <div>
                 {{ partial "helper/icon" "clock" }}
                 <time class="article-time--reading">

--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -34,7 +34,7 @@
             </div>
         {{ end }}
 
-    {{ if and (not (.Params.DisableReadTime | default false)) (.Site.Params.article.readingTime)}}
+    {{ if (.Params.readingTime | default (.Site.Params.article.readingTime)) }}
             <div>
                 {{ partial "helper/icon" "clock" }}
                 <time class="article-time--reading">


### PR DESCRIPTION
Add readingTime for pages like (contact, about, etc)

To disable showing readingTime add the following param in the `frontmatter` of the article

```yml
 readingTime: false
```

Notice: default value is `.Site.Params.article.readingTime`.