### PR TITLE
feat: add `rel=me` to social links

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -45,6 +45,7 @@
                         href='{{ .URL }}'
                         {{ if eq (default true .Params.newTab) true }}target="_blank"{{ end }}
                         {{ with .Name }}title="{{ . }}"{{ end }}
+                        rel="me"
                     >
                         {{ $icon := default "link" .Params.Icon }}
                         {{ with $icon }}


### PR DESCRIPTION
[rel="me"] is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.

[rel="me"]: https://indieweb.org/rel-me