### PR TITLE
fix(codeblock): pass through the options of chroma

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -342,6 +342,10 @@
             font-size: 14px;
             font-weight: bold;
         }
+
+        pre {
+            margin: 0;
+        }
     }
 
     .table-wrapper {

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -13,7 +13,7 @@
     </header>
     <code id="codeblock-id-{{ .Ordinal }}" style="display:none;">{{- .Inner -}}</code>
     {{- if transform.CanHighlight $lang -}}
-    <div class="{{ $class }}">{{- highlight .Inner $lang -}}</div>
+    <div class="{{ $class }}">{{- highlight .Inner $lang .Options -}}</div>
     {{- else -}}
     <pre><code class="{{ $class }}">{{- .Inner -}}</code></pre>
     {{- end -}}


### PR DESCRIPTION
**Note that this is a patch for v4.**

Pass through the options of chroma highlighting processing for whom may use some options in codeblock.

<details>
<summary>Example</summary>

This feature is documented [here](https://gohugo.io/content-management/syntax-highlighting/#highlighting-in-code-fences), but it seems not included in the exampleSite, so I use the example below.

~~~markdown
```cpp {linenos=true,hl_lines=11,linenostart=292}
float sceneSDF(vec3 p, out vec3 pColor) {
    pColor = vec3(1.0, 1.0, 1.0);
    
    vec4 pH = mk_homo(p);
    vec4 pTO = mk_trans(35.0, -5.0, -20.0) * mk_scale(1.5, 1.5, 1.0) * pH;
    
    float t1 = t1SDF(pTO.xyz);
    float t2 = t2SDF((mk_trans(-45.0, 0.0, 0.0) * pTO).xyz);
    float t3 = t3SDF((mk_trans(-80.0, 0.0, 0.0) * pTO).xyz);
    float t4 = t4SDF((mk_trans(-106.0, 0.0, 0.0) * pTO).xyz);
    float t5 = t5SDF(p - vec3(36.0, 10.0, 15.0), vec3(30.0, 5.0, 5.0), 2.0);
    
    float tmin = min(min(min(min(t1, t2), t3), t4), t5);
    return tmin;
}
```
~~~
Before: 
![image](https://user-images.githubusercontent.com/22931465/199233384-882de411-f876-4926-9d0a-2f0ee6f352d7.png)
After:
![image](https://user-images.githubusercontent.com/22931465/199233449-dcdca1c0-791c-49c7-a50b-9a19a8a45a3d.png)
</details>


Fix wrong margin value of codeblock without highlight. The margin is now use the value of `.article-content pre`.
<details>
<summary>Example</summary>

Before:
![image](https://user-images.githubusercontent.com/22931465/199234003-26afe704-07f6-409e-a58a-85d01f9f2167.png)
After:
![image](https://user-images.githubusercontent.com/22931465/199234078-b4eea0ff-f22d-41c1-8bd5-29cc4779afcd.png)
</details>

