### PR TITLE
github gist shortcode added

### DIFF
--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -1,0 +1,4 @@
+<script
+    type="application/javascript"
+    src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js"
+></script>


### PR DESCRIPTION
Hello,

Just a modest contribution to add github gist shortcode (equivalent to the existing gitlab snippet).

The shortcode is : `{{< github username gistid >}}`

As I don't saw contrib guide, I hope it will suit the project.

Thanks