### PR TITLE
fix: KaTeX may render contents in gist under certain conditions

### DIFF
--- a/layouts/partials/article/components/math.html
+++ b/layouts/partials/article/components/math.html
@@ -7,6 +7,7 @@
                 { left: "$", right: "$", display: false },
                 { left: "\\(", right: "\\)", display: false },
                 { left: "\\[", right: "\\]", display: true }
-            ]
+            ],
+            ignoredClasses: ["gist"]
         });})
 </script>


### PR DESCRIPTION
This is a bug I met, and it's not difficult to fix, so I fixed it and opened this PR.

**Bug description:** 
When the gist is loaded before katex renders, the gist codes between `$` are treated by katex as math contents. (The codeblock generated by github gist is not wrapped by any `<code>` tag.) 
Below is a screenshot of such render error.

![image](https://user-images.githubusercontent.com/43836984/211051078-725b929e-2178-43d9-ad52-8bd7084058e2.png)
(Related gist: https://gist.github.com/Furffico/f63e63cc192d77ca3c6bb5347f0a1d63)

**Solution:**
Simply add `gist` to `ignoredClasses` option of katex configuration would fix this bug.
