### PR TITLE
fix(sidebar): add `padding-bottom` to the right sidebar

### DIFF
--- a/assets/scss/partials/sidebar.scss
+++ b/assets/scss/partials/sidebar.scss
@@ -79,6 +79,7 @@
 
     @include respond(lg) {
         padding-top: var(--main-top-padding);
+        padding-bottom: var(--main-top-padding);
     }
 }
 


### PR DESCRIPTION
改动之后滑到页面底部时右侧边栏底部会有足够的留白