### PR TITLE
support additional source for webp for cover/content images

### DIFF
--- a/assets/ts/gallery.ts
+++ b/assets/ts/gallery.ts
@@ -93,9 +93,10 @@ class StackGallery {
             figure.appendChild(el);
 
             /// Add figcaption if it exists
-            if (img.hasAttribute('alt')) {
+            const childImg = img.querySelector('img')
+            if (childImg.hasAttribute('alt')) {
                 const figcaption = document.createElement('figcaption');
-                figcaption.innerText = img.getAttribute('alt');
+                figcaption.innerText = childImg.getAttribute('alt');
                 figure.appendChild(figcaption);
             }
 

--- a/assets/ts/gallery.ts
+++ b/assets/ts/gallery.ts
@@ -61,7 +61,7 @@ class StackGallery {
         /// because it can not detect whether image is being wrapped by a link or not
         /// and it lead to a invalid HTML construction (<a><figure><img></figure></a>)
 
-        const images = container.querySelectorAll('img.gallery-image');
+        const images = container.querySelectorAll('picture.gallery-image');
         for (const img of Array.from(images)) {
             /// Images are wrapped with figure tag if the paragraph has only images without texts
             /// This is done to allow inline images within paragraphs

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -24,9 +24,6 @@
 		class="gallery-image" 
 		data-flex-grow="{{ div (mul $image.Width 100) $image.Height }}"
 		data-flex-basis="{{ div (mul $image.Width 240) $image.Height }}px"
-		{{ with $alt }}
-			alt="{{ . }}"
-		{{ end }}
 	{{ end }}
 {{- end -}}
 
@@ -59,6 +56,9 @@
 	{{ with $Srcset }}srcset="{{ . }}"{{ end }}
 	loading="lazy"
 	decoding="async"
+	{{ with $alt }}
+		alt="{{ . }}"
+	{{ end }}
 >
 
 </picture>

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,6 +8,8 @@
 {{/* SVG and external images won't work with gallery layout, because their width and height attributes are unknown */}}
 {{- $galleryImage := false -}}
 
+<picture
+
 {{- if $image -}}
 	{{- $notSVG := ne (path.Ext .Destination) ".svg" -}}
 	{{- $Permalink = $image.RelPermalink -}}
@@ -16,8 +18,33 @@
 		{{- $Width = $image.Width -}}
 		{{- $Height = $image.Height -}}
 		{{- $galleryImage = true -}}
+	{{- end -}}
 
+	{{ if $galleryImage }}
+		class="gallery-image" 
+		data-flex-grow="{{ div (mul $image.Width 100) $image.Height }}"
+		data-flex-basis="{{ div (mul $image.Width 240) $image.Height }}px"
+		{{ with $alt }}
+			alt="{{ . }}"
+		{{ end }}
+	{{ end }}
+{{- end -}}
+
+>
+
+{{- if $image -}}
+	{{- $notSVG := ne (path.Ext .Destination) ".svg" -}}
+	{{- $Permalink = $image.RelPermalink -}}
+	{{- if $notSVG -}}
 		{{- if (default true .Page.Site.Params.imageProcessing.content.enabled) -}}
+			{{- $small := $image.Resize `webp 480x` -}}
+			{{- $big := $image.Resize `webp 1024x` -}}
+			{{- $Srcset = printf `%s 480w, %s 1024w` $small.RelPermalink $big.RelPermalink -}}
+
+			<source type="image/webp"
+				srcset="{{ $Srcset }}"
+			>
+
 			{{- $small := $image.Resize `480x` -}}
 			{{- $big := $image.Resize `1024x` -}}
 			{{- $Srcset = printf `%s 480w, %s 1024w` $small.RelPermalink $big.RelPermalink -}}
@@ -25,17 +52,13 @@
 	{{- end -}}
 {{- end -}}
 
+
 <img src="{{ $Permalink }}"
 	{{ with $Width }}width="{{ . }}"{{ end }}
 	{{ with $Height }}height="{{ . }}"{{ end }}
 	{{ with $Srcset }}srcset="{{ . }}"{{ end }}
 	loading="lazy"
-	{{ with $alt }}
-		alt="{{ . }}"
-	{{ end }}
-	{{ if $galleryImage }}
-		class="gallery-image" 
-		data-flex-grow="{{ div (mul $image.Width 100) $image.Height }}"
-		data-flex-basis="{{ div (mul $image.Width 240) $image.Height }}px"
-	{{ end }}
+	decoding="async"
 >
+
+</picture>

--- a/layouts/partials/article/components/header.html
+++ b/layouts/partials/article/components/header.html
@@ -9,7 +9,12 @@
                     {{- $Height := $image.resource.Height -}}
                     {{- $Srcset := "" -}}
                     
+                    <picture>
                     {{- if (default true .Page.Site.Params.imageProcessing.cover.enabled) -}}
+                        {{- $thumbnail := $image.resource.Resize "webp 800x" -}}
+                        {{- $thumbnailRetina := $image.resource.Resize "webp 1600x" -}}
+                        {{- $Srcset = printf "%s 800w, %s 1600w" $thumbnail.RelPermalink $thumbnailRetina.RelPermalink -}}
+                        <source type="image/webp" srcset="{{ $Srcset }}" />
                         {{- $thumbnail := $image.resource.Resize "800x" -}}
                         {{- $thumbnailRetina := $image.resource.Resize "1600x" -}}
                         {{- $Srcset = printf "%s 800w, %s 1600w" $thumbnail.RelPermalink $thumbnailRetina.RelPermalink -}}
@@ -22,8 +27,9 @@
                         {{ with $Srcset }}srcset="{{ . }}"{{ end }}
                         width="{{ $Width }}" 
                         height="{{ $Height }}" 
-                        loading="lazy"
+                        decoding="async"
                         alt="Featured image of post {{ .Title }}" />
+                    </picture>
                 {{ else }}
                     <img src="{{ $image.permalink }}" loading="lazy" alt="Featured image of post {{ .Title }}" />
                 {{ end }}


### PR DESCRIPTION
Best practices for web images is to organize them inside a picture tag and provide web optimized image formats.

Since Hugo now natively supports webp, this change wraps an image into a picture tag and provides an additional set of webp sources. The gallery css is moved from the img tag to the picture tag which required a small change to the gallery typescript.

You can check an example page that uses this at: https://www.provos.org/p/finetuning-stable-diffusion-part2/

Ps: This does not check whether the original image is webp already