### PR TITLE
feat(article): font enhancement

### DIFF
--- a/assets/scss/partials/article.scss
+++ b/assets/scss/partials/article.scss
@@ -54,6 +54,7 @@
 }
 
 .article-title {
+    font-family: var(--article-font-family);
     font-weight: 600;
     margin: 0;
     color: var(--card-text-color-main);

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -33,6 +33,10 @@
             margin: var(--card-padding) 0;
             color: var(--card-text-color-main);
 
+            .footnotes {
+                font-family: var(--base-font-family);
+            }
+
             img {
                 max-width: 100%;
                 height: auto;

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -44,7 +44,7 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
     --zh-font-family: "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei";
 
     --base-font-family: "Lato", var(--sys-font-family), var(--zh-font-family), sans-serif;
-    --code-font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    --code-font-family: Menlo, Monaco, Consolas, "Courier New", var(--zh-font-family), monospace;
 }
 
 /*


### PR DESCRIPTION
有以下修改：
1. 让正文标题使用`--article-font-family`字体设置。这样的话标题和正文是一种字体，副标题和其他部分仍然是`--base-font-family`，这样也增加了标题和副标题的区分度
2. 让脚注部分的文字默认使用`--base-font-family`字体，也是便于区分脚注和正文。我感觉脚注和正文分不清是hugo目前的一大问题，并且也没有改进的计划，使用字体区分至少是一种方法
3. 让代码块中的汉字不使用默认字体而是使用`--zh-font-family`（主要针对windows，默认字体是宋体，在16px以下的时候实在是太丑了）

这些修改应该都不影响默认设置下的显示效果（因为`--article-font-family`就是`--base-font-family`）