### PR TITLE
给一二级标题更突出的颜色

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -219,6 +219,17 @@
         padding-inline-start: calc(var(--card-padding) - var(--heading-border-size));
         border-inline-start: var(--heading-border-size) solid var(--accent-color);
     }
+    
+    h1,
+    h2 {
+        border-inline-start: var(--heading-border-size) solid var(--accent-color);
+    }
+    h3,
+    h4,
+    h5,
+    h6 {
+        border-inline-start: var(--heading-border-size) solid var(--accent-color-darker);
+    }
 
     figure {
         text-align: center;


### PR DESCRIPTION
给正文h3及以下级别的标题左侧的border使用深色accent color，这样标题之间更有区分度

修改前：
![image](https://user-images.githubusercontent.com/9154441/212757910-d004356d-a83d-4016-bc05-754e7b8026a7.png)
修改后：
![image](https://user-images.githubusercontent.com/9154441/212757857-7c681cb9-242f-4ec8-afbb-5befac02dc9f.png)
