### PR TITLE
feat(i18n): Allow localizing menus with i18n dynamically

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -62,7 +62,7 @@
         {{ range .Site.Menus.main }}
         {{ $active := or (eq $currentPage.Title .Name) (or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .)) }}
         <li {{ if $active }} class='current' {{ end }}>
-            <a href='{{ .URL }}' {{ if eq .Params.newTab true }}target="_blank"{{ end }}>
+            <a href='{{ .URL | absLangURL }}' {{ if eq .Params.newTab true }}target="_blank"{{ end }}>
                 {{ $icon := default .Pre .Params.Icon }}
                 {{ if .Pre }}
                     {{ warnf "Menu item [%s] is using [pre] field to set icon, please use [params.icon] instead.\nMore information: https://docs.stack.jimmycai.com/configuration/custom-menu.html" .URL }}
@@ -70,7 +70,7 @@
                 {{ with $icon }}
                     {{ partial "helper/icon" . }}
                 {{ end }}
-                <span>{{- .Name -}}</span>
+                <span>{{ i18n .Identifier | default .Name}}</span>
             </a>
         </li>
         {{ end }}


### PR DESCRIPTION
Adding feature described in this link:
[https://gohugo.io/content-management/multilingual/#dynamically-localizing-menus-with-i18n](https://gohugo.io/content-management/multilingual/#dynamically-localizing-menus-with-i18n)

I figure out two issue when adding `i18n/[language].toml` to the root directory like the link describe. 
First, the text in sidebar is not changing according to the language file. Even thought "identifier" is added in every element of the menu.
Second, clicking the sidebar button after changing language will redirect the page to its default language.

So I modify the corresponding html to solve this two problem.