### PR TITLE
Support explicitly related content in article frontmatter

### DIFF
--- a/layouts/partials/article/components/related-content.html
+++ b/layouts/partials/article/components/related-content.html
@@ -1,8 +1,8 @@
-{{ $related_posts := slice -}}
-{{ range .Params.related_posts -}}
-{{ $related_posts = $related_posts | append ($.Site.GetPage (printf "/post/%s" .)) -}}
+{{ $explicitly_related := slice -}}
+{{ range .Params.related -}}
+{{ $explicitly_related = $explicitly_related | append ($.Site.GetPage . ) -}}
 {{ end -}}
-{{ $related := $related_posts | append (where (.Site.RegularPages.Related .) "Params.hidden" "!=" true) | uniq | first 5 }}
+{{ $related := $explicitly_related | append (where (.Site.RegularPages.Related .) "Params.hidden" "!=" true) | uniq | first 5 }}
 {{ with $related }}
 <aside class="related-content--wrapper">
     <h2 class="section-title">{{ T "article.relatedContent" }}</h2>

--- a/layouts/partials/article/components/related-content.html
+++ b/layouts/partials/article/components/related-content.html
@@ -1,4 +1,8 @@
-{{ $related := (where (.Site.RegularPages.Related .) "Params.hidden" "!=" true) | first 5 }}
+{{ $related_posts := slice -}}
+{{ range .Params.related_posts -}}
+{{ $related_posts = $related_posts | append ($.Site.GetPage (printf "/post/%s" .)) -}}
+{{ end -}}
+{{ $related := $related_posts | append (where (.Site.RegularPages.Related .) "Params.hidden" "!=" true) | uniq | first 5 }}
 {{ with $related }}
 <aside class="related-content--wrapper">
     <h2 class="section-title">{{ T "article.relatedContent" }}</h2>


### PR DESCRIPTION
Sometimes the Hugo related content algorithm just doesn't do what you want.

This change allows to specify related content in the frontmatter of an article.  These take priority over any derived by Hugo by its related content algorithm.

For example, in TOML format:

```
related = [ "/post/a-compelling-read/index.md" ]
```

The paths are passed to `.Site.GetPage`, and this list prepended to the Hugo-generated related content, with duplicates removed.