### PR TITLE
fix: remark42 comment system won't show

### DIFF
--- a/layouts/partials/comments/provider/remark42.html
+++ b/layouts/partials/comments/provider/remark42.html
@@ -13,7 +13,7 @@
         show_email_subscription: {{ default true .show_email_subscription }}
     };
 
-    function(e, n) {
+    !function(e, n) {
         for (var o = 0; o < e.length; o++) {
             var r = n.createElement('script'),
             c = '.js',


### PR DESCRIPTION
From the [Remark42](https://remark42.com/docs/getting-started/installation/) installation guide, the code snippet right after config differs from the official guide. It needs to add `!` in front of the function.