### PR TITLE
fix: a waline config param with false value will be ignored

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
     </head>
     <body class="{{ block `body-class` . }}{{ end }}">
         {{- partial "head/colorScheme" . -}}
+        {{- partial "head/autoLang" . -}}
 
         {{/* The container is wider when there's any activated widget */}}
         {{- $hasWidget := false -}}

--- a/layouts/partials/comments/provider/waline.html
+++ b/layouts/partials/comments/provider/waline.html
@@ -19,7 +19,7 @@
 {{- $replaceKeys := dict "serverurl" "serverURL" "requiredmeta" "requiredMeta" "wordlimit" "wordLimit" "pagesize" "pageSize" "imageuploader" "imageUploader" "texrenderer" "texRenderer" -}}
 
 {{- range $key, $val := . -}}
-    {{- if $val -}}  
+    {{- if or $val (eq $val false) -}}  
         {{- $replaceKey := index $replaceKeys $key -}}
         {{- $k := default $key $replaceKey -}}
 

--- a/layouts/partials/head/autoLang.html
+++ b/layouts/partials/head/autoLang.html
@@ -1,0 +1,31 @@
+{{ if .Site.IsMultiLingual }}
+<script>
+    (function () {
+        const BASE_URL = '{{ .Site.BaseURL }}';
+        const DEFAULT_LANG = '{{ .Site.Language.Lang }}';
+
+        if (!window.location.href.endsWith(BASE_URL)) return;
+
+        let userLangList = [...navigator.languages];
+        if (localStorage.userLang)
+            userLangList.unshift(localStorage.userLang);
+        else
+            localStorage.userLang = userLangList[0].toLowerCase();
+
+        let supportLangs = new Set();
+        {{ range .Site.Languages }}
+        supportLangs.add('{{ .Lang }}');
+        {{ end }}
+        for (let userLang of userLangList) {
+            userLang = userLang.toLowerCase();
+            if (DEFAULT_LANG == userLang) {
+                return;
+            }
+            if (supportLangs.has(userLang)) {
+                window.location.href = window.location.href + userLang;
+                return;
+            }
+        }
+    })()
+</script>
+{{ end }}

--- a/layouts/partials/head/autoLang.html
+++ b/layouts/partials/head/autoLang.html
@@ -1,27 +1,25 @@
 {{ if .Site.IsMultiLingual }}
 <script>
     (function () {
-        const BASE_URL = '{{ .Site.BaseURL }}';
-        const DEFAULT_LANG = '{{ .Site.Language.Lang }}';
-
-        if (!window.location.href.endsWith(BASE_URL)) return;
-
+        if (window.location.pathname !== '/') return;        
+        
+        const CURRENT_LANG = '{{ .Site.Language.Lang }}';
+        
         let userLangList = [...navigator.languages];
         if (localStorage.userLang)
             userLangList.unshift(localStorage.userLang);
-        else
-            localStorage.userLang = userLangList[0].toLowerCase();
-
+        
         let supportLangs = new Set();
         {{ range .Site.Languages }}
         supportLangs.add('{{ .Lang }}');
         {{ end }}
         for (let userLang of userLangList) {
             userLang = userLang.toLowerCase();
-            if (DEFAULT_LANG == userLang) {
+            if (CURRENT_LANG == userLang) {
                 return;
             }
             if (supportLangs.has(userLang)) {
+                localStorage.userLang = userLang;
                 window.location.href = window.location.href + userLang;
                 return;
             }

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -80,9 +80,9 @@
             {{ with .Site.Home.AllTranslations }}
                 <li id="i18n-switch">  
                     {{ partial "helper/icon" "language" }}
-                    <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                    <select name="language" onchange="localStorage.userLang = this.selectedOptions[0].dataset.lang; window.location.href = this.selectedOptions[0].value">
                         {{ range . }}
-                            <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
+                            <option data-lang="{{ .Language.Lang }}" value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
                         {{ end }}
                     </select>
                 </li>


### PR DESCRIPTION
For example: `imageUploader` and `search` these two params will be ignored.

``` 
waline:
    lang:
    visitor:
    imageUploader: false
    search: false
    avatar:
    reaction: true
```