### PR TITLE
fix: invalid params used in requiredMeta of waline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,9 +73,8 @@ params:
             emoji:
                 - https://cdn.jsdelivr.net/gh/walinejs/emojis/weibo
             requiredMeta:
-                - name
-                - email
-                - url
+                - nick
+                - mail
             placeholder:
             locale:
                 admin: Admin


### PR DESCRIPTION
Fix the invalid parameters used in waline requiredMeta

Reference: https://waline.js.org/reference/client/props.html#commentsorting

## requiredMeta
- 类型: string[]
- 默认值: []

设置**必填项**，默认匿名，可选值:

- []
- ['nick']
- ['nick', 'mail']
