### PR TITLE
fix: a waline config param with false value will be ignored

### DIFF
--- a/layouts/partials/comments/provider/waline.html
+++ b/layouts/partials/comments/provider/waline.html
@@ -19,7 +19,7 @@
 {{- $replaceKeys := dict "serverurl" "serverURL" "requiredmeta" "requiredMeta" "wordlimit" "wordLimit" "pagesize" "pageSize" "imageuploader" "imageUploader" "texrenderer" "texRenderer" -}}
 
 {{- range $key, $val := . -}}
-    {{- if $val -}}  
+    {{- if ne $val nil -}}  
         {{- $replaceKey := index $replaceKeys $key -}}
         {{- $k := default $key $replaceKey -}}
 


### PR DESCRIPTION
For example: `imageUploader` and `search` these two params will be ignored.

``` 
waline:
    lang:
    visitor:
    imageUploader: false
    search: false
    avatar:
    reaction: true
```