### PR TITLE
Improve Font Rendering for Japanese Language

### DIFF
--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -42,9 +42,15 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 :root {
     --sys-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Droid Sans", "Helvetica Neue";
     --zh-font-family: "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei";
+    --cjk-font-family: "Source Han Sans", "Noto Sans CJK";
 
-    --base-font-family: "Lato", var(--sys-font-family), var(--zh-font-family), sans-serif;
+    --base-font-family: "Lato", var(--sys-font-family), var(--zh-font-family), var(--cjk-font-family), sans-serif;
     --code-font-family: Menlo, Monaco, Consolas, "Courier New", var(--zh-font-family), monospace;
+}
+
+:lang(ja) {
+    --ja-font-family: "Hiragino Kaku Gothic ProN", "Meiryo", "Noto Sans CJK JP";
+    --base-font-family: "Lato", var(--sys-font-family), var(--ja-font-family), var(--cjk-font-family), sans-serif;
 }
 
 /*


### PR DESCRIPTION
This pull request aims to improve the display of Japanese text on the website.

Changes made:
1. Introduced a new CSS variable, --ja-font-family, to specify a priority list of fonts for Japanese text.
2. Adjusted the --base-font-family variable for Japanese language context to prioritize --ja-font-family.

The new font family list prioritizes commonly available and high-quality fonts for Japanese text, such as "Hiragino Kaku Gothic ProN", "Meiryo", and "Noto Sans CJK JP". These changes will help to ensure that our Japanese text is displayed accurately and beautifully across various operating systems and browsers.

Please review the changes and let me know if any adjustments are needed.