### PR TITLE
Add rel attribute

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -45,6 +45,7 @@
                         href='{{ .URL }}'
                         {{ if eq (default true .Params.newTab) true }}target="_blank"{{ end }}
                         {{ with .Name }}title="{{ . }}"{{ end }}
+                        {{ if .Params.rel }}rel="{{ .Params.rel }}" {{ end }}
                     >
                         {{ $icon := default "link" .Params.Icon }}
                         {{ with $icon }}


### PR DESCRIPTION
Adds the `rel` attribute to social links to allow for [verified Mastodon links](https://joinmastodon.org/verification).

The configuration happens via the `rel` parameter in `menu.social.params`, e.g.

```toml
    [[menu.social]]
    url= "https://chaos.social/@phoenix"
    name = "Mastodon"
    [menu.social.params]
        icon = "brand-mastodon"
        rel = "me"
```

Example: https://feldspaten.org/ and my verified account https://chaos.social/@phoenix