### PR TITLE
fix(article): margin collapsing in code block (firefox)

### DIFF
--- a/assets/scss/partials/highlight/common.scss
+++ b/assets/scss/partials/highlight/common.scss
@@ -55,6 +55,7 @@
     margin-right: 0.4em;
     padding: 0 0.4em 0 0.4em;
     color: #7f7f7f;
+    display: block;
 }
 
 /* LineNumbers */


### PR DESCRIPTION
# Describe the problem
When enable line number in codeblock, margin collapsing happens in single line code block. cause the problem in the following image. 

![圖片](https://github.com/CaiJimmy/hugo-theme-stack/assets/39305460/717b4889-eb2d-4393-8954-e36fbccbb298)

# How to solve it
Add `display: block;` to `.lnt` in `assets/scss/partials/highlight/common.scss`
