### PR TITLE
doc: Inline math example previously not working as intended

### DIFF
--- a/exampleSite/content/post/math-typesetting/index.md
+++ b/exampleSite/content/post/math-typesetting/index.md
@@ -37,11 +37,7 @@ In this example we will be using [KaTeX](https://katex.org/)
 
 ### Examples
 
-{{< math.inline >}}
-<p>
-Inline math: \(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…\)
-</p>
-{{</ math.inline >}}
+Inline math: $\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…$
 
 Block math:
 $$


### PR DESCRIPTION
Issue:
- Delimiters `\( some KaTeX )\` not working as math environment

Solution:
- Use delimiters `$ some KaTeX $` instead. This functionality is supported in the latest version(s) of KaTeX.