### PR TITLE
fix(menu): consistent svg coloring in menu

### DIFF
--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -176,8 +176,8 @@
         }
 
         svg {
+            stroke: var(--body-text-color);
             stroke-width: 1.33;
-
             width: 20px;
             height: 20px;
         }

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -176,7 +176,7 @@
         }
 
         svg {
-            stroke: var(--body-text-color);
+            stroke: currentColor;
             stroke-width: 1.33;
             width: 20px;
             height: 20px;


### PR DESCRIPTION
Previously, the color of svgs in the menu were not consistent:

<img width="247" alt="image" src="https://github.com/CaiJimmy/hugo-theme-stack/assets/99768694/cf4694e2-a083-45e6-82fd-00164be6dc19">

<img width="242" alt="image" src="https://github.com/CaiJimmy/hugo-theme-stack/assets/99768694/fdfa59fe-56a8-4ee6-8907-bd0034784ecd">

Fixed coloring:
<img width="246" alt="image" src="https://github.com/CaiJimmy/hugo-theme-stack/assets/99768694/d4b1c751-80d4-44c9-b65a-15d5c21f1019">
<img width="242" alt="image" src="https://github.com/CaiJimmy/hugo-theme-stack/assets/99768694/9f68106c-4998-4be3-a2ba-decc41233737">

All I did was add:

stroke: var(--body-text-color);

to the svg attribute in menu.scss

