### PR TITLE
feat: allow footer copyright to be different to the site title

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -3,6 +3,7 @@ languageCode: en-us
 theme: hugo-theme-stack
 paginate: 5
 title: Example Site
+copyright: Example Person
 
 languages:
     en:

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -5,7 +5,7 @@
         {{ if and (.Site.Params.footer.since) (ne .Site.Params.footer.since (int (now.Format "2006"))) }}
             {{ .Site.Params.footer.since }} - 
         {{ end }}
-        {{ now.Format "2006" }} {{ .Site.Title }}
+        {{ now.Format "2006" }} {{ default .Site.Title .Site.Copyright }}
     </section>
     
     <section class="powerby">


### PR DESCRIPTION
Thanks for this theme!! Recently migrated my site to it and am happy with the results.

Just a small irritation to save me overriding a partial, we should allow the copyright to be set independently to the site title. Reasons for this are:

- The site title might not always match the entity that owns the copyright (ie, the site title might not be an individuals or companies name).
- The `rss.xml` template calls for `.Site.Copyright` so it is required for this to render properly and it does not make sense that the option does not affect the HTML copyright as well.

I've tried to retain the original behaviour so the change is not breaking - it will use `.Site.Title` if copyright is not individually set.

Auto-generation of the date is a nice touch so of course I want to keep that as it is.