### PR TITLE
fix: custom params on the language top level is deprecated

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -9,19 +9,22 @@ languages:
     en:
         languageName: English
         title: Example Site
-        description: Example description
         weight: 1
+        params:
+            description: Example description
     zh-cn:
         languageName: 中文
         title: 演示站点
-        description: 演示说明
         weight: 2
+        params:
+            description: 演示说明
     ar:
         languageName: عربي
         languagedirection: rtl
         title: موقع تجريبي
-        description: وصف تجريبي
         weight: 3
+        params:
+            description: وصف تجريبي
 
 # Change it to your Disqus shortname before using
 disqusShortname: hugo-theme-stack

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "exampleSite/public"
 
 [build.environment]
-    HUGO_VERSION = "0.100.2"
+    HUGO_VERSION = "0.117.0"
     HUGO_THEME = "repo"
 
 [context.production]


### PR DESCRIPTION
New with Hugo 0.112.0

closes #853