### PR TITLE
feat: use `.RelPermalink` for search JSON

### DIFF
--- a/layouts/page/search.html
+++ b/layouts/page/search.html
@@ -1,11 +1,11 @@
 {{ define "body-class" }}template-search{{ end }}
 {{ define "head" }}
     {{- with .OutputFormats.Get "json" -}} 
-        <link rel="preload" href="{{ .Permalink }}" as="fetch" crossorigin="anonymous">
+        <link rel="preload" href="{{ .RelPermalink }}" as="fetch" crossorigin="anonymous">
     {{- end -}}
 {{ end }}
 {{ define "main" }}
-<form action="{{ .Permalink }}" class="search-form"{{ with .OutputFormats.Get "json" -}} data-json="{{ .Permalink }}"{{- end }}>
+<form action="{{ .RelPermalink }}" class="search-form"{{ with .OutputFormats.Get "json" -}} data-json="{{ .RelPermalink }}"{{- end }}>
     <p>
         <label>{{ T "search.title" }}</label>
         <input name="keyword" placeholder="{{ T `search.placeholder` }}" />


### PR DESCRIPTION
Avoids CORS problem when the user inputs `baseurl` incorrectly.