### PR TITLE
fix: add `word-break: break-word;` to `<a>` and `<code>`

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -264,6 +264,11 @@
         font-family: var(--code-font-family);
     }
 
+    a,
+    code {
+        word-break: break-word;
+    }
+
     .gallery {
         position: relative;
         display: flex;


### PR DESCRIPTION
closes https://github.com/CaiJimmy/hugo-theme-stack/issues/746