### PR TITLE
fix(comments): twikoo icon & count text color not visible on dark theme

### DIFF
--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -15,6 +15,7 @@
     .twikoo .tk-action-icon,
     .twikoo .tk-submit-action-icon,
     .twikoo .tk-time,
+    .twikoo .tk-comments-no,
     .twikoo .tk-comments-count {
         color: var(--twikoo-body-text-color);
     }

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -13,6 +13,7 @@
     }
     .twikoo .el-input-group__prepend,
     .twikoo .tk-action-icon,
+    .twikoo .tk-submit-action-icon,
     .twikoo .tk-time,
     .twikoo .tk-comments-count {
         color: var(--twikoo-body-text-color);
@@ -27,6 +28,9 @@
     }
     .twikoo .el-button{
         color: var(--twikoo-body-text-color)!important;
+    }
+    .twikoo .el-input__count {
+        color: var(--twikoo-body-text-color) !important;
     }
     .OwO .OwO-body {
         background-color: var(--body-background) !important;


### PR DESCRIPTION
Fix css style

<img width="860" alt="image" src="https://github.com/CaiJimmy/hugo-theme-stack/assets/44677306/0d182e73-f548-479f-81ee-446472f79f5f">
