### PR TITLE
fix(comment): moved waline `placeholder` parameter to `locale.placeholder`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -64,7 +64,7 @@ params:
             clientSecret:
             autoCreateIssue: false
 
-        # Waline client configuration see: https://waline.js.org/en/reference/client.html
+        # Waline client configuration see: https://waline.js.org/en/reference/client/props.html
         waline:
             serverURL:
             lang:
@@ -75,9 +75,9 @@ params:
             requiredMeta:
                 - nick
                 - mail
-            placeholder:
             locale:
                 admin: Admin
+                placeholder:
 
         twikoo:
             envId:


### PR DESCRIPTION
1. fix placeholder location
2. update url

reference: https://waline.js.org/en/cookbook/customize/locale.html

