### PR TITLE
fix(sidebar): improve accessibility of sidebar bottom menu

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -74,8 +74,9 @@
             </a>
         </li>
         {{ end }}
-
-        <div class="menu-bottom-section">
+    </ol>
+    <div class="menu-bottom-section">
+        <ol class="menu">
             {{- $currentLanguageCode := .Language.Lang -}}
             {{ if ( compare.Gt .Site.Home.AllTranslations 1 ) }}
                 {{ with .Site.Home.AllTranslations }}
@@ -97,6 +98,6 @@
                     <span>{{ T "darkMode" }}</span>
                 </li>
             {{ end }}
-        </div>
-    </ol>
+        </ol>
+    </div>
 </aside>

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -82,7 +82,7 @@
                 {{ with .Site.Home.AllTranslations }}
                     <li id="i18n-switch">  
                         {{ partial "helper/icon" "language" }}
-                        <select name="language" onchange="window.location.href = this.selectedOptions[0].value">
+                        <select name="language" title="language" onchange="window.location.href = this.selectedOptions[0].value">
                             {{ range . }}
                                 <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
                             {{ end }}


### PR DESCRIPTION
- Move `<div class="menu-bottom-section">` outside `<ol class="menu" id="main-menu">` to fix warning `<li> elements must be contained in a <ul> or <ol>`

- Add `title="language"` to language select menu to fix error `Select element must have an accessible name: Element has no title attribute`

The appearance is identical after change.

Before:
![before](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/2d19805e-158c-4ec4-9bd5-c6f45cffb8ab)

After:
![after](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/f955099e-93e8-4b15-ab6d-0ba4642c0e2d)
