### PR TITLE
fix(widgets): ensure `params` is not nil

### DIFF
--- a/layouts/partials/sidebar/right.html
+++ b/layouts/partials/sidebar/right.html
@@ -4,7 +4,10 @@
     <aside class="sidebar right-sidebar sticky">
         {{ range $widget := . }}
             {{ if templates.Exists (printf "partials/widget/%s.html" .type) }}
-                {{ partial (printf "widget/%s" .type) (dict "Context" $context "Params" .params) }}
+                <!-- Ensure that the params always exist -->
+                {{- $params := .params | default (dict) -}}
+
+                {{ partial (printf "widget/%s" .type) (dict "Context" $context "Params" $params) }}
             {{ else }}
                 {{ warnf "Widget %s not found" .type }}
             {{ end }}

--- a/layouts/partials/sidebar/right.html
+++ b/layouts/partials/sidebar/right.html
@@ -4,8 +4,8 @@
     <aside class="sidebar right-sidebar sticky">
         {{ range $widget := . }}
             {{ if templates.Exists (printf "partials/widget/%s.html" .type) }}
-                <!-- Ensure that the params always exist -->
-                {{- $params := .params | default (dict) -}}
+                <!-- Ensure that the `params` is not nil -->
+                {{- $params := default dict .params -}}
 
                 {{ partial (printf "widget/%s" .type) (dict "Context" $context "Params" $params) }}
             {{ else }}


### PR DESCRIPTION
If the `params` key is not defined in the config file, you will get an error when getting any value for `.Params`:

```
nil pointer evaluating interface {}
```

This is because when the `params` key is undefined, `.Params` is nil **(note this is completely different from an empty map)**, and nil cannot be used as a map.

To fix this, just make sure `params` is always map and not nil.