### PR TITLE
fix: title does not show pagination data

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,7 +1,7 @@
 baseurl: https://example.com
 languageCode: en-us
 theme: hugo-theme-stack
-paginate: 5
+paginate: 3
 title: Example Site
 copyright: Example Person
 

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -5,7 +5,7 @@
 <meta name='description' content='{{ $description }}'>
 {{ with .Params.Keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
 
-{{- $title := partialCached "data/title" . .RelPermalink -}}
+{{- $title := partial "data/title" . -}}
 <title>{{ $title }}</title>
 
 <link rel='canonical' href='{{ .Permalink }}'>


### PR DESCRIPTION
This is caused by partialCached. It turns out that the `.RelPermalink` is the same for all pages generated by the paginator, so they will show the same title as the first page.

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/941