### PR TITLE
Possibility to disable comments in specific pages

### DIFF
--- a/layouts/partials/comments/include.html
+++ b/layouts/partials/comments/include.html
@@ -1,3 +1,5 @@
 {{ if .Site.Params.comments.enabled }}
-    {{ partial (printf "comments/provider/%s" .Site.Params.comments.provider) . }}
+    {{ if not .Page.Params.comments.disabled }}
+        {{ partial (printf "comments/provider/%s" .Site.Params.comments.provider) . }}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
This pull request adds the possibility to disable comments in specific pages and posts, even if they are enabled globally.

For example to disable comments in a page, just add this:

```yaml
comments:
  disabled: true
```

in the post meta data.

**NOTE**: I would be glad to also update the documentation, once this is accepted and merge but it's not clear how that should be done (I don't see any docs in this repository)