### PR TITLE
fix(sidebar): translation selector - avoid cast per PR #950 

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -77,7 +77,7 @@
 
         <div class="menu-bottom-section">
             {{- $currentLanguageCode := .Language.Lang -}}
-            {{ if ( compare.Gt .Site.Home.AllTranslations 1 ) }}
+            {{ if ( compare.Gt .Site.Home.AllTranslations.Len 1 ) }}
                 {{ with .Site.Home.AllTranslations }}
                     <li id="i18n-switch">  
                         {{ partial "helper/icon" "language" }}


### PR DESCRIPTION
Follow up to PR #950 to avoid casting Site.Home.AllTranslations to retrieve count of configured site translations.