### PR TITLE
fix(sidebar): menu-bottom-section not showing in mobile

### DIFF
--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -141,12 +141,14 @@
     margin: 0 calc(var(--container-padding) * -1);
 
     padding: 30px 30px;
+
     @include respond(xl) {
         padding: 15px 0;
     }
 
-    & {
+    &, .menu-bottom-section ol {
         gap: 30px;
+
         @include respond(xl) {
             gap: 25px;
         }
@@ -163,10 +165,6 @@
         padding: 0;
         box-shadow: none;
         margin: 0;
-    }
-
-    li:last-of-type {
-        margin-top: auto;
     }
 
     li {
@@ -204,18 +202,15 @@
             }
         }
 
-        .menu-bottom-section {
+        &.menu-bottom-section {
+            margin-top: auto;
+
             ol {
                 margin-top: auto;
                 display: flex;
                 flex-direction: column;
                 width: 100%;
                 padding-left: 0;
-                gap: 30px;
-
-                @include respond(xl) {
-                    gap: 25px;
-                }
             }
         }
     }

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -145,8 +145,7 @@
         padding: 15px 0;
     }
 
-    &,
-    .menu-bottom-section {
+    & {
         gap: 30px;
         @include respond(xl) {
             gap: 25px;
@@ -206,13 +205,17 @@
         }
 
         .menu-bottom-section {
-            margin-top: auto;
-            display: flex;
-            flex-direction: column;
-            width: 100%;
-
             ol {
+                margin-top: auto;
+                display: flex;
+                flex-direction: column;
+                width: 100%;
                 padding-left: 0;
+                gap: 30px;
+
+                @include respond(xl) {
+                    gap: 25px;
+                }
             }
         }
     }

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -206,7 +206,6 @@
 
             ol {
                 display: flex;
-                width: 100%;
                 padding-left: 0;
             }
         }

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -129,7 +129,6 @@
 /* Menu style */
 #main-menu {
     list-style: none;
-    flex-direction: column;
     overflow-y: auto;
     flex-grow: 1;
     font-size: 1.4rem;
@@ -146,6 +145,7 @@
     }
 
     &, .menu-bottom-section ol {
+        flex-direction: column;
         gap: 30px;
 
         @include respond(xl) {
@@ -206,7 +206,6 @@
 
             ol {
                 display: flex;
-                flex-direction: column;
                 width: 100%;
                 padding-left: 0;
             }

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -128,7 +128,6 @@
 
 /* Menu style */
 #main-menu {
-    padding-left: 0;
     list-style: none;
     flex-direction: column;
     overflow-y: auto;

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -205,7 +205,6 @@
             margin-top: auto;
 
             ol {
-                margin-top: auto;
                 display: flex;
                 flex-direction: column;
                 width: 100%;

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -127,7 +127,7 @@
 }
 
 /* Menu style */
-.menu {
+#main-menu {
     padding-left: 0;
     list-style: none;
     flex-direction: column;
@@ -200,13 +200,17 @@
                 font-weight: bold;
             }
         }
-    }
 
-    .menu-bottom-section {
-        margin-top: auto;
-        display: flex;
-        flex-direction: column;
-        width: 100%;
+        .menu-bottom-section {
+            margin-top: auto;
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+
+            ol {
+                padding-left: 0;
+            }
+        }
     }
 }
 

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -166,6 +166,10 @@
         margin: 0;
     }
 
+    li:last-of-type {
+        margin-top: auto;
+    }
+
     li {
         position: relative;
         vertical-align: middle;

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -74,30 +74,32 @@
             </a>
         </li>
         {{ end }}
-    </ol>
-    <div class="menu-bottom-section">
-        <ol class="menu">
-            {{- $currentLanguageCode := .Language.Lang -}}
-            {{ if ( compare.Gt .Site.Home.AllTranslations.Len 1 ) }}
-                {{ with .Site.Home.AllTranslations }}
-                    <li id="i18n-switch">  
-                        {{ partial "helper/icon" "language" }}
-                        <select name="language" title="language" onchange="window.location.href = this.selectedOptions[0].value">
-                            {{ range . }}
-                                <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
-                            {{ end }}
-                        </select>
-                    </li>
-                {{ end }}
-            {{ end }}
+        <li>
+            <div class="menu-bottom-section">
+                <ol class="menu">
+                    {{- $currentLanguageCode := .Language.Lang -}}
+                    {{ if ( compare.Gt .Site.Home.AllTranslations.Len 1 ) }}
+                        {{ with .Site.Home.AllTranslations }}
+                            <li id="i18n-switch">  
+                                {{ partial "helper/icon" "language" }}
+                                <select name="language" title="language" onchange="window.location.href = this.selectedOptions[0].value">
+                                    {{ range . }}
+                                        <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
+                                    {{ end }}
+                                </select>
+                            </li>
+                        {{ end }}
+                    {{ end }}
 
-            {{ if (default false .Site.Params.colorScheme.toggle) }}
-                <li id="dark-mode-toggle">
-                    {{ partial "helper/icon" "toggle-left" }}
-                    {{ partial "helper/icon" "toggle-right" }}
-                    <span>{{ T "darkMode" }}</span>
-                </li>
-            {{ end }}
-        </ol>
-    </div>
+                    {{ if (default false .Site.Params.colorScheme.toggle) }}
+                        <li id="dark-mode-toggle">
+                            {{ partial "helper/icon" "toggle-left" }}
+                            {{ partial "helper/icon" "toggle-right" }}
+                            <span>{{ T "darkMode" }}</span>
+                        </li>
+                    {{ end }}
+                </ol>
+            </div>
+        </li>
+    </ol>
 </aside>

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -74,32 +74,30 @@
             </a>
         </li>
         {{ end }}
-        <li>
-            <div class="menu-bottom-section">
-                <ol class="menu">
-                    {{- $currentLanguageCode := .Language.Lang -}}
-                    {{ if ( compare.Gt .Site.Home.AllTranslations.Len 1 ) }}
-                        {{ with .Site.Home.AllTranslations }}
-                            <li id="i18n-switch">  
-                                {{ partial "helper/icon" "language" }}
-                                <select name="language" title="language" onchange="window.location.href = this.selectedOptions[0].value">
-                                    {{ range . }}
-                                        <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
-                                    {{ end }}
-                                </select>
-                            </li>
-                        {{ end }}
-                    {{ end }}
-
-                    {{ if (default false .Site.Params.colorScheme.toggle) }}
-                        <li id="dark-mode-toggle">
-                            {{ partial "helper/icon" "toggle-left" }}
-                            {{ partial "helper/icon" "toggle-right" }}
-                            <span>{{ T "darkMode" }}</span>
+        <li class="menu-bottom-section">
+            <ol class="menu">
+                {{- $currentLanguageCode := .Language.Lang -}}
+                {{ if ( compare.Gt .Site.Home.AllTranslations.Len 1 ) }}
+                    {{ with .Site.Home.AllTranslations }}
+                        <li id="i18n-switch">  
+                            {{ partial "helper/icon" "language" }}
+                            <select name="language" title="language" onchange="window.location.href = this.selectedOptions[0].value">
+                                {{ range . }}
+                                    <option value="{{ .Permalink }}" {{ if eq .Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
+                                {{ end }}
+                            </select>
                         </li>
                     {{ end }}
-                </ol>
-            </div>
+                {{ end }}
+
+                {{ if (default false .Site.Params.colorScheme.toggle) }}
+                    <li id="dark-mode-toggle">
+                        {{ partial "helper/icon" "toggle-left" }}
+                        {{ partial "helper/icon" "toggle-right" }}
+                        <span>{{ T "darkMode" }}</span>
+                    </li>
+                {{ end }}
+            </ol>
         </li>
     </ol>
 </aside>


### PR DESCRIPTION
PR #925 moved `menu-bottom-section` outside `main-menu` which made it to disappear in mobile. This PR fixes it by moving `menu-bottom-section` back to `main-menu` as `li` and adjusting stylesheets.

Before (desktop)
![desktop_before](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/50fb3eaf-468e-405c-afcc-483bbbe80e95)

After (desktop)
![desktop_after](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/6b138b93-ac57-4f53-998e-1118ffb4d146)

Before (mobile)
![mobile_before](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/45eeeaa1-51a3-4afa-9b10-1cb073048961)

After (mobile)
![mobile_after](https://github.com/CaiJimmy/hugo-theme-stack/assets/42709836/e4c8dbc9-5a31-4e0b-9845-878c6d4b1cf2)