### PR TITLE
fix: `.Site.LastChange` deprecation

### DIFF
--- a/exampleSite/content/page/about/index.md
+++ b/exampleSite/content/page/about/index.md
@@ -15,7 +15,7 @@ menu:
             icon: user
 ---
 
-Written in Go, Hugo is an open source static site generator available under the [Apache Licence 2.0.](https://github.com/gohugoio/hugo/blob/master/LICENSE) Hugo supports TOML, YAML and JSON data file types, Markdown and HTML content files and uses shortcodes to add rich content. Other notable features are taxonomies, multilingual mode, image processing, custom output formats, HTML/CSS/JS minification and support for Sass SCSS workflows.
+Written in Go, Hugo is an open source static site generator available under the [Apache License 2.0.](https://github.com/gohugoio/hugo/blob/master/LICENSE) Hugo supports TOML, YAML and JSON data file types, Markdown and HTML content files and uses shortcodes to add rich content. Other notable features are taxonomies, multilingual mode, image processing, custom output formats, HTML/CSS/JS minification and support for Sass SCSS workflows.
 
 Hugo makes use of a variety of open source projects including:
 
@@ -29,6 +29,6 @@ Hugo is ideal for blogs, corporate websites, creative portfolios, online magazin
 
 Hugo is for people who want to hand code their own website without worrying about setting up complicated runtimes, dependencies and databases.
 
-Websites built with Hugo are extremelly fast, secure and can be deployed anywhere including, AWS, GitHub Pages, Heroku, Netlify and any other hosting provider.
+Websites built with Hugo are extremely fast, secure and can be deployed anywhere including, AWS, GitHub Pages, Heroku, Netlify and any other hosting provider.
 
 Learn more and contribute on [GitHub](https://github.com/gohugoio).

--- a/layouts/partials/head/opengraph/provider/base.html
+++ b/layouts/partials/head/opengraph/provider/base.html
@@ -32,8 +32,8 @@
         <meta property='article:modified_time' content='{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}'/>
     {{- end -}}
 {{- else -}}
-    {{- if not .Site.LastChange.IsZero -}}
-        <meta property='og:updated_time' content='{{ .Site.LastChange.Format " 2006-01-02T15:04:05-07:00 " | safeHTML }}'/>
+    {{- if not .Site.Lastmod.IsZero -}}
+        <meta property='og:updated_time' content='{{ .Site.Lastmod.Format " 2006-01-02T15:04:05-07:00 " | safeHTML }}'/>
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This PR fixes the following deprecation warning emitted from hugo:

```
INFO  deprecated: .Site.LastChange was deprecated in Hugo v0.123.0
and will be removed in a future release. Use .Site.Lastmod instead.
```
It fixes two typos on the way as well.