### PR TITLE
fix: favicon does not load if baseurl includes a subfolder

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -19,7 +19,7 @@
 {{- end -}}
 
 {{ with .Site.Params.favicon }}
-    <link rel="shortcut icon" href="{{ . }}" />
+    <link rel="shortcut icon" href="{{ . | relURL }}" />
 {{ end }}
 
 {{- template "_internal/google_analytics.html" . -}}


### PR DESCRIPTION
https://github.com/CaiJimmy/hugo-theme-stack/issues/922#issuecomment-1987336952

As requested, PR created with fix