### PR TITLE
fix: use page resource permalink in link image

### DIFF
--- a/layouts/partials/article/components/links.html
+++ b/layouts/partials/article/components/links.html
@@ -16,8 +16,12 @@
                 </div>
         
                 {{ with $link.image }}
+                    {{ $permalink := . }}
+                    {{ with ($.Resources.GetMatch (printf "%s" (. | safeURL))) }}
+                        {{ $permalink = .RelPermalink }}
+                    {{ end }}
                     <div class="article-image">
-                        <img src="{{ . }}" loading="lazy">
+                        <img src="{{ $permalink }}" loading="lazy">
                     </div>
                 {{ end }}
             </a>


### PR DESCRIPTION
closes https://github.com/CaiJimmy/hugo-theme-stack/issues/982