### PR TITLE
fix: rename `.social-menu` to `.menu-social` to avoid being blocked by ad blockers

### DIFF
--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -212,7 +212,7 @@
     }
 }
 
-.social-menu {
+.menu-social {
     list-style: none;
     padding: 0;
     margin: 0;

--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -38,7 +38,7 @@
     </header>
 
     {{- with .Site.Menus.social -}}
-        <ol class="social-menu">
+        <ol class="menu-social">
             {{ range . }}
                 <li>
                     <a 


### PR DESCRIPTION
closes https://github.com/CaiJimmy/hugo-theme-stack/issues/924