### PR TITLE
fix: make KaTeX render all math inside `document.body`

### DIFF
--- a/layouts/partials/article/components/math.html
+++ b/layouts/partials/article/components/math.html
@@ -1,7 +1,7 @@
 {{- partial "helper/external" (dict "Context" . "Namespace" "KaTeX") -}}
 <script>
     window.addEventListener("DOMContentLoaded", () => {
-        renderMathInElement(document.querySelector(`.article-content`), {
+        renderMathInElement(document.body, {
             delimiters: [
                 { left: "$$", right: "$$", display: true },
                 { left: "$", right: "$", display: false },


### PR DESCRIPTION
Since it only accepts one element, I cannot pass `.article-content` and `#TableOfContent` to it. The official documentation uses `document.body` directly, so I guess that's fine.

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/882