### PR TITLE
[exampleSite toc] set default value tableOfContents.startLevel = 1 to avoid confusion

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -240,7 +240,7 @@ markup:
     tableOfContents:
         endLevel: 4
         ordered: true
-        startLevel: 2
+        startLevel: 1
     highlight:
         noClasses: false
         codeFences: true


### PR DESCRIPTION
Because of this setting, everyone may have doubts and think it's a bug.
For example, this one #749 
So, considering this, let's set it's default value to 1 directly.