### PR TITLE
fix: rename `.social-menu` to `.menu-social` to avoid being blocked by ad blocker

### DIFF
--- a/assets/scss/partials/sidebar.scss
+++ b/assets/scss/partials/sidebar.scss
@@ -65,7 +65,7 @@
         }
     }
 
-    .social-menu,
+    .menu-social,
     #main-menu {
         margin-top: var(--sidebar-element-separation);
     }


### PR DESCRIPTION
#993 
missing case in v4.
![image](https://github.com/CaiJimmy/hugo-theme-stack/assets/22931465/71965879-f6cb-4044-ad38-2e424e77f589)