### PR TITLE
doc: add backslash to `baseURL` in exampleSite

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -1,4 +1,4 @@
-baseurl: https://example.com
+baseurl: https://example.com/
 languageCode: en-us
 theme: hugo-theme-stack
 paginate: 3


### PR DESCRIPTION
baseURL should end in a backslash.