### PR TITLE
feat(comments): add support to Gitalk `proxy` parameter

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -156,6 +156,7 @@ params:
             repo:
             clientID:
             clientSecret:
+            proxy:
 
         cusdis:
             host:

--- a/layouts/partials/comments/provider/gitalk.html
+++ b/layouts/partials/comments/provider/gitalk.html
@@ -15,7 +15,7 @@
         admin: ["{{- .admin -}}"],
         distractionFreeMode: false, // Facebook-like distraction free mode
         id: md5(location.pathname), // Max Location.pathname Legth:75  https://github.com/gitalk/gitalk/issues/102
-        proxy: {{- .proxy }},
+        proxy: {{- .proxy -}},
     });
     (function () {
         if (

--- a/layouts/partials/comments/provider/gitalk.html
+++ b/layouts/partials/comments/provider/gitalk.html
@@ -15,6 +15,7 @@
         admin: ["{{- .admin -}}"],
         distractionFreeMode: false, // Facebook-like distraction free mode
         id: md5(location.pathname), // Max Location.pathname Legth:75  https://github.com/gitalk/gitalk/issues/102
+        proxy: {{- .proxy }},
     });
     (function () {
         if (


### PR DESCRIPTION
I found missing proxy configuration for gitalk and added it