### PR TITLE
chore: bump Twikoo front-end to latest released version `1.6.39`

### DIFF
--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.35/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.36/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.34/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.35/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.21/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.34/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.38/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.39/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.36/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.38/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {


### PR DESCRIPTION
This PR bumps Twikoo front-end to latest released version 1.6.34.