### PR TITLE
chore: bump Twikoo ver to 1.6.35

### DIFF
--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.21/dist/twikoo.all.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/twikoo@1.6.35/dist/twikoo.all.min.js" integrity="sha384-JsEdSbRBa/2uU41AieN8G3sgGYhuiNjM5ZeB4yRkJa6mUzGgXWDI0E/zmj+ByWPA" crossorigin="anonymous"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {

--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/twikoo@1.6.35/dist/twikoo.all.min.js" integrity="sha384-JsEdSbRBa/2uU41AieN8G3sgGYhuiNjM5ZeB4yRkJa6mUzGgXWDI0E/zmj+ByWPA" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/twikoo@1.6.36/dist/twikoo.all.min.js" integrity="sha384-4KfOjEinLSkv1i1J8TzlkC/RTnuiLoR1OLerVgjEKoH5djYtbf7mzEFsz9p3nfuA" crossorigin="anonymous"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {


### PR DESCRIPTION
Bump Twikoo JS library to version [1.6.35](https://github.com/twikoojs/twikoo/releases/tag/1.6.35).

Mandate HTTPS protocol to avoid possible downgrade attack.

The PR also adds [integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to mitigate potential supply-chain attacks.
