### PR TITLE
[feature] widget->categories/tags, add <a> tag link to Category/Tags list

### DIFF
--- a/layouts/partials/widget/categories.html
+++ b/layouts/partials/widget/categories.html
@@ -4,7 +4,9 @@
     <div class="widget-icon">
         {{ partial "helper/icon" "categories" }}
     </div>
-    <h2 class="widget-title section-title">{{ T "widget.categoriesCloud.title" }}</h2>
+    <h2 class="widget-title section-title">
+	<a href="{{ "categories" | relLangURL }}">{{ T "widget.categoriesCloud.title" }}</a>
+    </h2>
 
     <div class="tagCloud-tags">
         {{ range first $limit $context.Site.Taxonomies.categories.ByCount }}

--- a/layouts/partials/widget/tag-cloud.html
+++ b/layouts/partials/widget/tag-cloud.html
@@ -4,7 +4,9 @@
     <div class="widget-icon">
         {{ partial "helper/icon" "tag" }}
     </div>
-    <h2 class="widget-title section-title">{{ T "widget.tagCloud.title" }}</h2>
+    <h2 class="widget-title section-title">
+	<a href="{{ "tags" | relLangURL }}">{{ T "widget.tagCloud.title" }}</a>
+    </h2>
 
     <div class="tagCloud-tags">
         {{ range first $limit $context.Site.Taxonomies.tags.ByCount }}


### PR DESCRIPTION
I found that there is no <a> link to categories/tags list page.
So, consider add a <a> link to the widget title. And the user interface experience is almost the same as before.