### PR TITLE
fix: displaying category blocks in `.article-category` (#1045)

### DIFF
--- a/assets/scss/partials/article.scss
+++ b/assets/scss/partials/article.scss
@@ -148,6 +148,11 @@
     }
 }
 
+.article-category {
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
 /* Compact style article list */
 .article-list--compact {
     border-radius: var(--card-border-radius);


### PR DESCRIPTION
See #1045