### PR TITLE
fix(i18n): fix unlocalized article publish/lastUpdated date

### DIFF
--- a/layouts/partials/article/components/details.html
+++ b/layouts/partials/article/components/details.html
@@ -32,7 +32,7 @@
             <div>
                 {{ partial "helper/icon" "date" }}
                 <time class="article-time--published">
-                    {{- .Date.Format (or .Site.Params.dateFormat.published "Jan 02, 2006") -}}
+                    {{- .Date | time.Format (or .Site.Params.dateFormat.published "Jan 02, 2006") -}}
                 </time>
             </div>
         {{ end }}

--- a/layouts/partials/article/components/footer.html
+++ b/layouts/partials/article/components/footer.html
@@ -12,7 +12,7 @@
     <section class="article-lastmod">
         {{ partial "helper/icon" "clock" }}
         <span>
-            {{ T "article.lastUpdatedOn" }} {{ .Lastmod.Format ( or .Site.Params.dateFormat.lastUpdated "Jan 02, 2006 15:04 MST" ) }}
+            {{ T "article.lastUpdatedOn" }} {{ .Lastmod | time.Format ( or .Site.Params.dateFormat.lastUpdated "Jan 02, 2006 15:04 MST" ) }}
         </span>
     </section>
     {{- end -}}


### PR DESCRIPTION
**Issue:**

From https://github.com/CaiJimmy/hugo-theme-stack/issues/1040

Setting `defaultContentLanguage` in `hugo.yaml` doesn't localize article publish and last modified dates.

![image of the unlocalized article publish and last modified dates](https://github.com/user-attachments/assets/c5e7f9e4-99fc-4889-a7ac-564dce6177fa)

**Proposed Solution:**

This pull request addresses the missing localization for article dates by leveraging the `time.Format` function introduced in [Hugo v0.87](https://github.com/gohugoio/hugo/releases/tag/v0.87.0).
