### PR TITLE
fix(i18n): missing translation for title of categories widget in fr.yaml

### DIFF
--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -50,6 +50,9 @@ widget:
     tagCloud:
         title:
             other: Mots clés
+    categoriesCloud:
+        title:
+            other: Catégories
 
 search:
     title:


### PR DESCRIPTION
Add translation for categories widget in french