### PR TITLE
fix(colorScheme): systemPreferScheme not initialized on start up

### DIFF
--- a/assets/ts/colorScheme.ts
+++ b/assets/ts/colorScheme.ts
@@ -8,6 +8,10 @@ class StackColorScheme {
     constructor(toggleEl: HTMLElement) {
         this.bindMatchMedia();
         this.currentScheme = this.getSavedScheme();
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches === true)
+            this.systemPreferScheme = 'dark'
+        else
+            this.systemPreferScheme = 'light';
 
         this.dispatchEvent(document.documentElement.dataset.scheme as colorScheme);
 


### PR DESCRIPTION
This will cause that `systemPreferScheme` is undefined when toggle color scheme by clicking button, unless the `onColorSchemeChange` event occurs at least once.

The following code will never reach: https://github.com/CaiJimmy/hugo-theme-stack/blob/v3.27.0/assets/ts/colorScheme.ts#L37-L40

```ts
            if (this.currentScheme == this.systemPreferScheme) {
                /// Set to auto
                this.currentScheme = 'auto';
            }
```

I believe this is not the expected behavior.

---

The unexpected behavior has been verified on the following browsers:

Google Chrome 128.0.6613.137:

![image](https://github.com/user-attachments/assets/b6d0fce0-dc69-4919-b09c-fcf3f7f9f4f2)

Mozilla Firefox 130.0:

![image](https://github.com/user-attachments/assets/713cc1c5-dc49-4297-9f6f-abefced84d8c)

On device: `Linux cryolitia-gpd-nixos 6.10.9-zen1 #1-NixOS ZEN SMP PREEMPT_DYNAMIC Tue Jan  1 00:00:00 UTC 1980 x86_64 GNU/Linux`