### PR TITLE
fix: Correct Lastmod field access in OpenGraph meta tags

### DIFF
--- a/layouts/partials/head/opengraph/provider/base.html
+++ b/layouts/partials/head/opengraph/provider/base.html
@@ -32,8 +32,8 @@
         <meta property='article:modified_time' content='{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}'/>
     {{- end -}}
 {{- else -}}
-    {{- if not .Site.Lastmod.IsZero -}}
-        <meta property='og:updated_time' content='{{ .Site.Lastmod.Format " 2006-01-02T15:04:05-07:00 " | safeHTML }}'/>
+    {{- if not .Site.LastChange.IsZero -}}
+        <meta property='og:updated_time' content='{{ .Site.LastChange.Format "2006-01-02T15:04:05-07:00" | safeHTML }}'/>
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
- Updated the OpenGraph meta tags to correctly access the Lastmod field.
- For pages, use .Lastmod instead of .Site.Lastmod.
- For non-pages, use .Site.LastChange instead of .Site.Lastmod.
- Ensured proper formatting for published and modified times in OpenGraph meta tags.

The original content caused issues on Cloudflare Pages due to incorrect access of the Lastmod field, leading to build failures.

[cloudflare pages building.log](https://github.com/user-attachments/files/17173349/cloudflare.pages.building.log)