### PR TITLE
Fix: Language-specific sidebar params for subtitle and emoji

### DIFF
--- a/layouts/partials/sidebar/left.html
+++ b/layouts/partials/sidebar/left.html
@@ -24,7 +24,7 @@
                     {{ end }}
                 {{ end }}
                 </a>
-                {{ with $.Site.Params.sidebar.emoji }}
+                {{ with $.Site.Language.Params.sidebar.emoji }}
                     <span class="emoji">{{ . }}</span>
                 {{ end }}
             </figure>
@@ -33,7 +33,7 @@
         
         <div class="site-meta">
             <h1 class="site-name"><a href="{{ .Site.BaseURL | relLangURL }}">{{ .Site.Title }}</a></h1>
-            <h2 class="site-description">{{ .Site.Params.sidebar.subtitle }}</h2>
+            <h2 class="site-description">{{ .Site.Language.Params.sidebar.subtitle }}</h2>
         </div>
     </header>
 


### PR DESCRIPTION
**Title:**

Fix: Use language-specific params for sidebar subtitle and emoji

**Description:**

This pull request updates the sidebar template to support language-specific `subtitle` and `emoji` parameters. Instead of using global values from `.Site.Params`, the changes use `.Site.Language.Params` to allow different values for each language configured in `languages.toml`.

**Changes:**

- Updated `layouts/partials/sidebar/left.html` to reference `.Site.Language.Params.sidebar.subtitle` and `.Site.Language.Params.sidebar.emoji`.
- Ensured that `languages.toml` can now define `subtitle` and `emoji` for each language separately.

**Why:**

This change allows multilingual sites to customize the sidebar text and emoji for each language, enhancing the user experience and ensuring the correct language context is displayed. One may want to use country-related flags as emojis, or untranslatable language-specific phrase/joke/quote as the subtitle.

**How to test:**

1. Define different `subtitle` and `emoji` values in `languages.toml` for multiple languages.
2. Run the site and switch between languages to confirm that the sidebar displays the correct values for each language.

Thanks for reviewing this PR! Looking forward to your feedback :)
