### PR TITLE
fix(giscus): fallback to `en` if no language code is set

### DIFF
--- a/layouts/partials/comments/provider/giscus.html
+++ b/layouts/partials/comments/provider/giscus.html
@@ -11,7 +11,7 @@
     data-emit-metadata="{{- default 0 .emitMetadata -}}"
     data-input-position="{{- default `top` .inputPosition -}}"
     data-theme="{{- default `light` .lightTheme -}}"
-    data-lang="{{- default $.Language.LanguageCode .lang -}}"
+    data-lang="{{- default (default `en` $.Language.LanguageCode) .lang -}}"
     data-loading="{{- .loading -}}"
     crossorigin="anonymous"
     async


### PR DESCRIPTION
fix https://github.com/CaiJimmy/hugo-theme-stack/issues/1083