### PR TITLE
Fix Categories widget shadow missing at top-left

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -51,6 +51,8 @@
     .article-list--tile {
         display: flex;
         padding-bottom: 15px;
+        padding-top: 8px;
+        padding-left: 8px;
 
         article {
             width: 250px;


### PR DESCRIPTION
wait，i will pull new to fix another question
.subsection-list { overflow: visible;}