### PR TITLE
A fix to decode special characters in the search bar on 404 pages

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -36,7 +36,7 @@
             const wrongUrl = new URL(window.location.href);
 
             /// Get the search keyword from the wrong URL by removing all slashes and dashes
-            const searchKeyword = wrongUrl.pathname.split(/[/|-]/).join(' ').trim();
+            const searchKeyword = decodeURIComponent(wrongUrl.pathname).split(/[/|-]/).join(' ').trim();
 
             document.getElementById('searchInput').setAttribute('value', searchKeyword);
         </script>


### PR DESCRIPTION
The accompanying fix for issue #1097, allowing unicode characters to work correctly in 404 pages.