### PR TITLE
Inline Code Block Handling Issue in Chromium-Based Browsers

### DIFF
--- a/layouts/partials/article/components/content.html
+++ b/layouts/partials/article/components/content.html
@@ -1,5 +1,6 @@
 <section class="article-content">
     <!-- Refer to https://discourse.gohugo.io/t/responsive-tables-in-markdown/10639/5 -->
     {{ $wrappedTable := printf "<div class=\"table-wrapper\">${1}</div>" }}
-    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
+    {{ $wrappedInlineCodeBlock := printf "<span>${1}</span>" }}
+    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | replaceRE "(<code>.*?</code>)" $wrappedInlineCodeBlock | safeHTML }}
 </section>


### PR DESCRIPTION
Dear Owner,

Regarding the handling of inline code blocks, I’ve encountered an issue specifically in Microsoft Edge. When translating, it moves all `<code>` tags to the end of the paragraph, causing formatting disruptions and readability challenges.

After testing, I found that wrapping `<code>` tags with `<span>` resolves the issue, allowing proper parsing and translation.

This issue seems to stem from the browser itself. Notably, it does not occur in Safari. Initially, I thought this was limited to Edge, but further investigation revealed that all Chromium-based browsers exhibit this behavior when processing `<code>` tags. They tend to move these tags to the end of the text block during translation.

Interestingly, this bug appears to have existed since 2020 (or perhaps even earlier), as documented in the following references:

1. [Edge's built-in translation breaks typography](https://techcommunity.microsoft.com/discussions/edgeinsiderdiscussions/edges-built-in-translation-breaks-typography/3419254)

2. [The translator always move the code tag content to the end](https://techcommunity.microsoft.com/discussions/edgeinsiderdiscussions/the-translator-always-move-the-code-tag-content-to-the-end/1906043)

As a workaround, adding `<span>` tags around the `<code>` blocks has proven to be an effective solution. While not ideal, it ensures readability and proper translation behavior across affected browsers. I hope this insight can help others encountering the same issue.

Best regards,
Wells