### PR TITLE
fix(comment/waline): cannot read property ‘insertBefore’ of null

### DIFF
--- a/layouts/partials/article/components/math.html
+++ b/layouts/partials/article/components/math.html
@@ -8,6 +8,6 @@
                 { left: "\\(", right: "\\)", display: false },
                 { left: "\\[", right: "\\]", display: true }
             ],
-            ignoredClasses: ["gist"]
+            ignoredClasses: ["gist","waline-container"]
         });})
 </script>

--- a/layouts/partials/article/components/math.html
+++ b/layouts/partials/article/components/math.html
@@ -1,13 +1,14 @@
 {{- partial "helper/external" (dict "Context" . "Namespace" "KaTeX") -}}
 <script>
     window.addEventListener("DOMContentLoaded", () => {
-        renderMathInElement(document.body, {
+	const mainArticleElement = document.querySelector(".main-article");
+        renderMathInElement(mainArticleElement, {
             delimiters: [
                 { left: "$$", right: "$$", display: true },
                 { left: "$", right: "$", display: false },
                 { left: "\\(", right: "\\)", display: false },
                 { left: "\\[", right: "\\]", display: true }
             ],
-            ignoredClasses: ["gist","waline-container"]
+            ignoredClasses: ["gist"]
         });})
 </script>


### PR DESCRIPTION
When I use the waline compoment to build comment section for my blog,the comment  data couldn't pull and raise Error "Cannot read property ‘insertBefore’ of null".then I get the answer from #1044 and guess that it's due to the Katex renders before the waline compoments.
Add "waline-container` to `ignoredClasses` could work.But changing the element to render KateX may be used for most of situations,that allows each comment system to use their own Latex renderer.

Hope this helps you!