### PR TITLE
Use ResizeObserver to detect changes in the size of .article-content

### DIFF
--- a/assets/ts/scrollspy.ts
+++ b/assets/ts/scrollspy.ts
@@ -125,6 +125,15 @@ function setupScrollspy() {
         scrollHandler();
     }
 
+    // Use ResizeObserver to detect changes in the size of .article-content
+    const articleContent = document.querySelector(".article-content");
+    if (articleContent) {
+        const resizeObserver = new ResizeObserver(() => {
+            resizeHandler();
+        });
+        resizeObserver.observe(articleContent);
+}
+
     window.addEventListener("resize", debounced(resizeHandler));
 }
 


### PR DESCRIPTION
This code is for handling changes in position caused by content rendered as part of post-processing, such as Mermaid diagrams