### PR TITLE
feat: add Bluesky comments support

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,6 +25,12 @@
 
 {{ define "main" }}
     {{ partial "article/article.html" . }}
+    
+    {{ with .Params.bsky_post }}
+        {{ if . }}
+            {{ partial "bsky-comments.html" . }}
+        {{ end }}
+    {{ end }}
 
     {{ if .Params.links }}
         {{ partial "article/components/links" . }}

--- a/layouts/partials/comments/bsky-comments.html
+++ b/layouts/partials/comments/bsky-comments.html
@@ -1,0 +1,29 @@
+<script type="module" src="https://cdn.jsdelivr.net/gh/Siya-33/static@1.2.7/js/bsky-comments.js"></script>
+<bsky-comments post="{{ . }}" ></bsky-comments>
+<style>
+    bsky-comments {
+        --background-color: var(--card-background);
+        --text-color: var(--card-text-color-main);
+        --link-color: var(--code-text-color);
+        --comment-meta-color: #5E9595;
+        --error-color: red;
+        --reply-border-color: transparent;
+        --button-background-color: var(--code-background-color);
+        --author-avatar-border-radius: 100%;
+    }
+</style>
+<!-- custom style -->
+<!-- <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const bskyComments = document.querySelector('bsky-comments');
+    if (bskyComments) {
+      const style = document.createElement('style');
+      style.textContent = `
+        comments {
+          border-radius: var(--card-border-radius);
+        }
+      `;
+      bskyComments.shadowRoot.appendChild(style);
+    }
+  });
+</script> -->


### PR DESCRIPTION
[demo](https://www.shirakii.com/post/bluesky-comments/) here

need to add params in markdown `bsky_post: <data-bluesky-uri>`

Since it is disconnected from the original comment system, whether to merge it depends on the author's willingness.

Someone else's post is embedded here for demonstration


https://github.com/user-attachments/assets/6a6c8927-eaac-4e13-8e8c-88ade8772e49

Thank you for your check