### PR TITLE
Add figure caption rendering

### DIFF
--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -46,7 +46,7 @@
             
             figcaption {
                 margin-top: 0.5em;
-                font-size: 0.8em;
+                font-size: 0.9em;
                 color: var(--card-text-color-secondary);
                 font-style: italic;
                 font-weight: bold;

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -40,6 +40,17 @@
             img {
                 max-width: 100%;
                 height: auto;
+                display: block; 
+                margin: 0 auto;
+            }
+            
+            figcaption {
+                margin-top: 0.5em;
+                font-size: 0.8em;
+                color: var(--card-text-color-secondary);
+                font-style: italic;
+                font-weight: bold;
+                text-align: center;
             }
         }
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,6 +1,7 @@
 {{- $image := .Page.Resources.GetMatch (printf "%s" (.Destination | safeURL)) -}}
 {{- $Permalink := .Destination | relURL | safeURL -}}
 {{- $alt := .PlainText | safeHTML -}}
+{{- $title := .Title | safeHTML -}}
 {{- $Width := 0 -}}
 {{- $Height := 0 -}}
 {{- $Srcset := "" -}}
@@ -39,3 +40,6 @@
 		data-flex-basis="{{ div (mul $image.Width 240) $image.Height }}px"
 	{{ end }}
 >
+{{- if $title }}
+<figcaption>{{ .Title }}</figcaption>
+{{- end }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -41,5 +41,5 @@
 	{{ end }}
 >
 {{- if $title }}
-<figcaption>{{ .Title | markdownify }}</figcaption>
+<figcaption>{{ .Title | }}</figcaption>
 {{- end }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,7 +1,7 @@
 {{- $image := .Page.Resources.GetMatch (printf "%s" (.Destination | safeURL)) -}}
 {{- $Permalink := .Destination | relURL | safeURL -}}
 {{- $alt := .PlainText | safeHTML -}}
-{{- $title := .Title | safeHTML -}}
+{{- $title := .Title | markdownify | safeHTML -}}
 {{- $Width := 0 -}}
 {{- $Height := 0 -}}
 {{- $Srcset := "" -}}
@@ -41,5 +41,5 @@
 	{{ end }}
 >
 {{- if $title }}
-<figcaption>{{ .Title }}</figcaption>
+<figcaption>{{ .Title | markdownify }}</figcaption>
 {{- end }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -41,5 +41,5 @@
 	{{ end }}
 >
 {{- if $title }}
-<figcaption>{{ .Title | }}</figcaption>
+<figcaption>{{ .Title }}</figcaption>
 {{- end }}


### PR DESCRIPTION
When inserting an image using the standard markdown syntax `![](img_url "caption")`, the image caption cannot be rendered. 

Now support for image caption rendering has been added, and HTML and KaTeX rendering is supported

Effect show in below:
![image](https://github.com/user-attachments/assets/585a15d5-9da9-4000-a2f6-ccb4154334ba)