### PR TITLE
fix(giscus): no longer use `$.Language.LanguageCode` for the language of Giscus

### DIFF
--- a/layouts/partials/comments/provider/giscus.html
+++ b/layouts/partials/comments/provider/giscus.html
@@ -11,7 +11,7 @@
     data-emit-metadata="{{- default 0 .emitMetadata -}}"
     data-input-position="{{- default `top` .inputPosition -}}"
     data-theme="{{- default `light` .lightTheme -}}"
-    data-lang="{{- default (default `en` $.Language.LanguageCode) .lang -}}"
+    data-lang="{{- default `en` .lang -}}"
     data-loading="{{- .loading -}}"
     crossorigin="anonymous"
     async


### PR DESCRIPTION
rollback #1075

closes #1117 

User can still customize the language used for Giscus using `.Site.Params.comments.giscus.lang` parameter.
