### PR TITLE
refactor(comments): use `includes` instead of `indexOf` to improve readability

### DIFF
--- a/layouts/partials/comments/provider/disqusjs.html
+++ b/layouts/partials/comments/provider/disqusjs.html
@@ -21,8 +21,12 @@
         }
 
         function lazyLoadDisqusJS() {
-            if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1) {
-                document.getElementById('disqus_thread').innerHTML = 'Disqus comments not available by default when the website is previewed locally.';
+            const excludedHosts = ["localhost", "127.0.0.1"];
+            const hostname = window.location.hostname;
+
+            if (excludedHosts.includes(hostname)) {
+                document.getElementById('disqus_thread').innerHTML =
+                    'Disqus comments not available by default when the website is previewed locally.';
                 return;
             }
 

--- a/layouts/partials/comments/provider/gitalk.html
+++ b/layouts/partials/comments/provider/gitalk.html
@@ -18,9 +18,10 @@
         proxy: {{- .proxy -}},
     });
     (function () {
-        if (
-            ["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1
-        ) {
+        const excludedHosts = ["localhost", "127.0.0.1"];
+        const hostname = window.location.hostname;
+
+        if (excludedHosts.includes(hostname)) {
             document.getElementById("gitalk-container").innerHTML =
                 "Gitalk comments not available by default when the website is previewed locally.";
             return;


### PR DESCRIPTION
Here are the refactored code snippets for both Gitalk and DisqusJS, which improve readability by using the includes() method instead of indexOf():
- Gitalk: 758dc25
- DisqusJS: 1950a66