### PR TITLE
Render math formula for the table of contents

### DIFF
--- a/layouts/partials/article/components/math.html
+++ b/layouts/partials/article/components/math.html
@@ -1,14 +1,21 @@
 {{- partial "helper/external" (dict "Context" . "Namespace" "KaTeX") -}}
 <script>
     window.addEventListener("DOMContentLoaded", () => {
-	const mainArticleElement = document.querySelector(".main-article");
-        renderMathInElement(mainArticleElement, {
-            delimiters: [
-                { left: "$$", right: "$$", display: true },
-                { left: "$", right: "$", display: false },
-                { left: "\\(", right: "\\)", display: false },
-                { left: "\\[", right: "\\]", display: true }
-            ],
-            ignoredClasses: ["gist"]
-        });})
+        const elementsToRender = [".main-article", ".widget--toc"];
+
+        elementsToRender.forEach(selector => {
+            const element = document.querySelector(selector);
+            if (element) {
+                renderMathInElement(element, {
+                    delimiters: [
+                        { left: "$$", right: "$$", display: true },
+                        { left: "$", right: "$", display: false },
+                        { left: "\\(", right: "\\)", display: false },
+                        { left: "\\[", right: "\\]", display: true }
+                    ],
+                    ignoredClasses: ["gist"]
+                });
+            }
+        });
+    });
 </script>


### PR DESCRIPTION
Just a minor fix about the math render for table of contents. 

From the most recent release, #1103 introduced a change to restrict the math render region from the whole document to the element ".main-article". This enables LaTeX rendering provided by comment systems.

However, this prevents rendering of math formulae in the table of contents. So a quick fix can be just add the toc elements into the render list. Maybe in the furture some others can add their math-living elements to be rendered in that list as well.

Here's a comparsion between changing it or not.

|Before:|After: |
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/4c8d7632-a033-4e08-8ff3-5760b07b43fa)|![image](https://github.com/user-attachments/assets/a8fd894d-1f22-41c9-b4f7-a169879cef82)|

Hope this can help someone writes math formulae in (sub)titles as well!