### PR TITLE
Add multiple colour palettes

### DIFF
--- a/assets/scss/palettes/blue.scss
+++ b/assets/scss/palettes/blue.scss
@@ -1,0 +1,80 @@
+/*
+* Blue palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #e7f5ff;
+
+    --accent-color: #2e8edd;
+    --accent-color-darker: #1864ab;
+    --accent-color-text: #ffffff;
+    --body-text-color: #1c7ed6;
+
+    --scrollbar-thumb: #a5d8ff;
+
+    &[data-scheme="dark"] {
+        --body-background: #001b33;
+        --accent-color: #4dabf7;
+        --accent-color-darker: #228be6;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #1864ab;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #f1f9ff;
+    --card-background-selected: #dbeeff;
+
+    --card-text-color-main: #000;
+    --card-text-color-secondary: #5b6b77;
+    --card-text-color-tertiary: #5a6b78;
+    --card-separator-color: rgba(139,173,206,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #2b3e50;
+        --card-background-selected: rgba(255,255,255,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(255,255,255,0.7);
+        --card-text-color-tertiary: rgba(255,255,255,0.5);
+        --card-separator-color: rgba(255,255,255,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #e1f3fe;
+
+    --link-background-color: 189, 195, 199;
+
+    --pre-background-color: #272822;
+    --pre-text-color: #f8f8f2;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #339af0;
+    --tr-even-background-color: #e1f3fe;
+
+    --kbd-border-color: #339af0;
+
+    &[data-scheme="dark"] {
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #2b5b82;
+        --tr-even-background-color: #002e55;
+
+        --blockquote-background-color: #002e55;
+    }
+}

--- a/assets/scss/palettes/blue.scss
+++ b/assets/scss/palettes/blue.scss
@@ -57,8 +57,8 @@
 
     --link-background-color: 189, 195, 199;
 
-    --pre-background-color: #272822;
-    --pre-text-color: #f8f8f2;
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
 
     --code-background-color: rgba(0, 0, 0, 0.12);
     --code-text-color: #808080;
@@ -69,6 +69,8 @@
     --kbd-border-color: #339af0;
 
     &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
         --code-background-color: #272822;
         --code-text-color: rgba(255,255,255,0.9);
 

--- a/assets/scss/palettes/common.scss
+++ b/assets/scss/palettes/common.scss
@@ -1,3 +1,7 @@
+/*
+* common scss across all palettes
+*/
+
 $defaultTagBackgrounds: #8ea885, #df7988, #0177b8, #ffb900, #6b69d6;
 $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
@@ -11,27 +15,13 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
         --main-top-padding: 50px;
     }
 
-    --body-background: #f5f5fa;
-
-    --accent-color: #34495e;
-    --accent-color-darker: #2c3e50;
-    --accent-color-text: #fff;
-    --body-text-color: #707070;
-
     --tag-border-radius: 4px;
 
     --section-separation: 40px;
 
-    --scrollbar-thumb: hsl(0, 0%, 85%);
     --scrollbar-track: var(--body-background);
 
     &[data-scheme="dark"] {
-        --body-background: #303030;
-        --accent-color: #ecf0f1;
-        --accent-color-darker: #bdc3c7;
-        --accent-color-text: #000;
-        --body-text-color: rgba(255, 255, 255, 0.7);
-        --scrollbar-thumb: hsl(0, 0%, 40%);
         --scrollbar-track: var(--body-background);
     }
 }
@@ -51,14 +41,6 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 *   Card style
 */
 :root {
-    --card-background: #fff;
-    --card-background-selected: #eaeaea;
-
-    --card-text-color-main: #000;
-    --card-text-color-secondary: #747474;
-    --card-text-color-tertiary: #767676;
-    --card-separator-color: rgba(218, 218, 218, 0.5);
-
     --card-border-radius: 10px;
 
     --card-padding: 20px;
@@ -75,15 +57,6 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 
     @include respond(md) {
         --small-card-padding: 25px;
-    }
-
-    &[data-scheme="dark"] {
-        --card-background: #424242;
-        --card-background-selected: rgba(255, 255, 255, 0.16);
-        --card-text-color-main: rgba(255, 255, 255, 0.9);
-        --card-text-color-secondary: rgba(255, 255, 255, 0.7);
-        --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
-        --card-separator-color: rgba(255, 255, 255, 0.12);
     }
 }
 
@@ -106,34 +79,12 @@ $defaultTagColors: #fff, #fff, #fff, #fff, #fff;
 */
 :root {
     --blockquote-border-size: 4px;
-    --blockquote-background-color: rgb(248 248 248);
 
     --heading-border-size: 4px;
 
-    --link-background-color: 189, 195, 199;
     --link-background-opacity: 0.5;
     --link-background-opacity-hover: 0.7;
 
-    --pre-background-color: #272822;
-    --pre-text-color: #f8f8f2;
-
-    --code-background-color: rgba(0, 0, 0, 0.12);
-    --code-text-color: #808080;
-
-    --table-border-color: #dadada;
-    --tr-even-background-color: #efefee;
-
-    --kbd-border-color: #dadada;
-
-    &[data-scheme="dark"] {
-        --code-background-color: #272822;
-        --code-text-color: rgba(255, 255, 255, 0.9);
-
-        --table-border-color: #717171;
-        --tr-even-background-color: #545454;
-
-        --blockquote-background-color: rgb(75 75 75);
-    }
 }
 
 /*

--- a/assets/scss/palettes/default.scss
+++ b/assets/scss/palettes/default.scss
@@ -1,0 +1,80 @@
+/*
+* Default palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #f5f5fa;
+
+    --accent-color: #34495e;
+    --accent-color-darker: #2c3e50;
+    --accent-color-text: #fff;
+    --body-text-color: #707070;
+
+    --scrollbar-thumb: hsl(0, 0%, 85%);
+
+    &[data-scheme="dark"] {
+        --body-background: #303030;
+        --accent-color: #ecf0f1;
+        --accent-color-darker: #bdc3c7;
+        --accent-color-text: #000;
+        --body-text-color: rgba(255, 255, 255, 0.7);
+        --scrollbar-thumb: hsl(0, 0%, 40%);
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #fff;
+    --card-background-selected: #eaeaea;
+
+    --card-text-color-main: #000;
+    --card-text-color-secondary: #747474;
+    --card-text-color-tertiary: #767676;
+    --card-separator-color: rgba(218, 218, 218, 0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #424242;
+        --card-background-selected: rgba(255, 255, 255, 0.16);
+        --card-text-color-main: rgba(255, 255, 255, 0.9);
+        --card-text-color-secondary: rgba(255, 255, 255, 0.7);
+        --card-text-color-tertiary: rgba(255, 255, 255, 0.5);
+        --card-separator-color: rgba(255, 255, 255, 0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: rgb(248 248 248);
+
+    --link-background-color: 189, 195, 199;
+
+    --pre-background-color: #272822;
+    --pre-text-color: #f8f8f2;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #dadada;
+    --tr-even-background-color: #efefee;
+
+    --kbd-border-color: #dadada;
+
+    &[data-scheme="dark"] {
+        --code-background-color: #272822;
+        --code-text-color: rgba(255, 255, 255, 0.9);
+
+        --table-border-color: #717171;
+        --tr-even-background-color: #545454;
+
+        --blockquote-background-color: rgb(75 75 75);
+    }
+}

--- a/assets/scss/palettes/default.scss
+++ b/assets/scss/palettes/default.scss
@@ -57,8 +57,8 @@
 
     --link-background-color: 189, 195, 199;
 
-    --pre-background-color: #272822;
-    --pre-text-color: #f8f8f2;
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
 
     --code-background-color: rgba(0, 0, 0, 0.12);
     --code-text-color: #808080;
@@ -69,6 +69,8 @@
     --kbd-border-color: #dadada;
 
     &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
         --code-background-color: #272822;
         --code-text-color: rgba(255, 255, 255, 0.9);
 

--- a/assets/scss/palettes/green.scss
+++ b/assets/scss/palettes/green.scss
@@ -1,0 +1,82 @@
+/*
+* Green palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #e7ffe7;
+
+    --accent-color: #2ecc71;
+    --accent-color-darker: #28a745;
+    --accent-color-text: #ffffff;
+    --body-text-color: #1c7e1c;
+
+    --scrollbar-thumb: #a5f5a5;
+
+    &[data-scheme="dark"] {
+        --body-background: #001b12;
+        --accent-color: #4daf7f;
+        --accent-color-darker: #228b45;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #186d34;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #f1fff1;
+    --card-background-selected: #dbeedb;
+
+    --card-text-color-main: #000;
+    --card-text-color-secondary: #5b776b;
+    --card-text-color-tertiary: #5a6b5a;
+    --card-separator-color: rgba(139,173,139,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #2b503e;
+        --card-background-selected: rgba(0,128,0,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(255,255,255,0.7);
+        --card-text-color-tertiary: rgba(255,255,255,0.5);
+        --card-separator-color: rgba(139,173,139,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #e1fbe1;
+
+    --link-background-color: 189, 199, 189;
+
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #33aa33;
+    --tr-even-background-color: #e1fbe1;
+
+    --kbd-border-color: #33aa33;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #2b7b2b;
+        --tr-even-background-color: #002e22;
+
+        --blockquote-background-color: #002e22;
+    }
+}

--- a/assets/scss/palettes/high-contrast.scss
+++ b/assets/scss/palettes/high-contrast.scss
@@ -1,0 +1,82 @@
+/*
+* High Contrast palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #ffffff;
+
+    --accent-color: #000000;
+    --accent-color-darker: #222222;
+    --accent-color-text: #ffffff;
+    --body-text-color: #000000;
+
+    --scrollbar-thumb: #333333;
+
+    &[data-scheme="dark"] {
+        --body-background: #000000;
+        --accent-color: #ffffff;
+        --accent-color-darker: #cccccc;
+        --accent-color-text: #000000;
+        --body-text-color: #ffffff;
+        --scrollbar-thumb: #cccccc;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #e5e5e5;
+    --card-background-selected: #bfbfbf;
+
+    --card-text-color-main: #000000;
+    --card-text-color-secondary: #333333;
+    --card-text-color-tertiary: #666666;
+    --card-separator-color: rgba(0,0,0,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #1a1a1a;
+        --card-background-selected: #333333;
+        --card-text-color-main: #ffffff;
+        --card-text-color-secondary: #cccccc;
+        --card-text-color-tertiary: #999999;
+        --card-separator-color: rgba(255,255,255,0.5);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #f0f0f0;
+
+    --link-background-color: 0, 0, 0;
+
+    --pre-background-color: #ffffff;
+    --pre-text-color: #000000;
+
+    --code-background-color: #f0f0f0;
+    --code-text-color: #000000;
+
+    --table-border-color: #000000;
+    --tr-even-background-color: #e5e5e5;
+
+    --kbd-border-color: #000000;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #ffffff;
+        --code-background-color: #272822;
+        --code-text-color: #ffffff;
+
+        --table-border-color: #ffffff;
+        --tr-even-background-color: #1a1a1a;
+
+        --blockquote-background-color: #1a1a1a;
+    }
+}

--- a/assets/scss/palettes/orange.scss
+++ b/assets/scss/palettes/orange.scss
@@ -1,0 +1,82 @@
+/*
+* Orange palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #fff3e0;
+
+    --accent-color: #ff9800;
+    --accent-color-darker: #f57c00;
+    --accent-color-text: #ffffff;
+    --body-text-color: #e65100;
+
+    --scrollbar-thumb: #ffcc80;
+
+    &[data-scheme="dark"] {
+        --body-background: #4e342e;
+        --accent-color: #ffb74d;
+        --accent-color-darker: #fb8c00;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #e64a19;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #fff8e1;
+    --card-background-selected: #ffe0b2;
+
+    --card-text-color-main: #000000;
+    --card-text-color-secondary: #e65100;
+    --card-text-color-tertiary: #f57c00;
+    --card-separator-color: rgba(255,152,0,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #5d4037;
+        --card-background-selected: rgba(255,183,77,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(255,204,128,0.7);
+        --card-text-color-tertiary: rgba(255,204,128,0.5);
+        --card-separator-color: rgba(255,204,128,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #fff0e0;
+
+    --link-background-color: 255, 152, 0;
+
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #ff9800;
+    --tr-even-background-color: #fff0e0;
+
+    --kbd-border-color: #ff9800;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #f57c00;
+        --tr-even-background-color: #4e342e;
+
+        --blockquote-background-color: #4e342e;
+    }
+}

--- a/assets/scss/palettes/pink.scss
+++ b/assets/scss/palettes/pink.scss
@@ -1,0 +1,81 @@
+/*
+* Pink palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #fff0f6;
+
+    --accent-color: #ff69b4;
+    --accent-color-darker: #d6336c;
+    --accent-color-text: #ffffff;
+    --body-text-color: #ad1457;
+    --scrollbar-thumb: #ffb3d9;
+
+    &[data-scheme="dark"] {
+        --body-background: #330617;
+        --accent-color: #ff85a2;
+        --accent-color-darker: #bf3f65;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #d63384;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #fff8fa;
+    --card-background-selected: #ffd6e8;
+
+    --card-text-color-main: #000;
+    --card-text-color-secondary: #5b3a4b;
+    --card-text-color-tertiary: #55343d;
+    --card-separator-color: rgba(221,51,102,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #3a1c2e;
+        --card-background-selected: rgba(255,255,255,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(255,255,255,0.7);
+        --card-text-color-tertiary: rgba(255,255,255,0.5);
+        --card-separator-color: rgba(255,255,255,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #ffe6f0;
+
+    --link-background-color: 255, 182, 193;
+
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #ff66b2;
+    --tr-even-background-color: #ffe6f0;
+
+    --kbd-border-color: #ff66b2;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #bf3f65;
+        --tr-even-background-color: #3d0d14;
+
+        --blockquote-background-color: #3d0d14;
+    }
+}

--- a/assets/scss/palettes/purple.scss
+++ b/assets/scss/palettes/purple.scss
@@ -1,0 +1,82 @@
+/*
+* Purple palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #f3e5f5;
+
+    --accent-color: #9c27b0;
+    --accent-color-darker: #6a1b9a;
+    --accent-color-text: #ffffff;
+    --body-text-color: #4a148c;
+
+    --scrollbar-thumb: #ce93d8;
+
+    &[data-scheme="dark"] {
+        --body-background: #2a0d2e;
+        --accent-color: #ba68c8;
+        --accent-color-darker: #8e24aa;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #6a1b9a;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #f8eafc;
+    --card-background-selected: #e1bee7;
+
+    --card-text-color-main: #000000;
+    --card-text-color-secondary: #7b1fa2;
+    --card-text-color-tertiary: #6a1b9a;
+    --card-separator-color: rgba(156,39,176,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #3d2c3e;
+        --card-background-selected: rgba(186,104,200,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(172, 82, 157,0.7);
+        --card-text-color-tertiary: rgba(172, 82, 157,0.5);
+        --card-separator-color: rgba(172, 82, 157,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #f1e7f4;
+
+    --link-background-color: 156, 39, 176;
+
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #9c27b0;
+    --tr-even-background-color: #f1e7f4;
+
+    --kbd-border-color: #9c27b0;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #6a1b9a;
+        --tr-even-background-color: #2a0d2e;
+
+        --blockquote-background-color: #2a0d2e;
+    }
+}

--- a/assets/scss/palettes/red.scss
+++ b/assets/scss/palettes/red.scss
@@ -1,0 +1,82 @@
+/*
+* Red palette
+*/
+
+@import "common.scss";
+
+/*
+*   Global style
+*/
+:root {
+    --body-background: #ffe7e7;
+
+    --accent-color: #e53935;
+    --accent-color-darker: #b71c1c;
+    --accent-color-text: #ffffff;
+    --body-text-color: #c62828;
+
+    --scrollbar-thumb: #ef9a9a;
+
+    &[data-scheme="dark"] {
+        --body-background: #330000;
+        --accent-color: #ff5252;
+        --accent-color-darker: #e53935;
+        --accent-color-text: #ffffff;
+        --body-text-color: rgba(255,255,255,0.8);
+        --scrollbar-thumb: #b71c1c;
+    }
+}
+
+/*
+*   Card style
+*/
+:root {
+    --card-background: #ffebee;
+    --card-background-selected: #ffcdd2;
+
+    --card-text-color-main: #000000;
+    --card-text-color-secondary: #d32f2f;
+    --card-text-color-tertiary: #c62828;
+    --card-separator-color: rgba(229,115,115,0.5);
+
+    &[data-scheme="dark"] {
+        --card-background: #4e0e0e;
+        --card-background-selected: rgba(255,82,82,0.16);
+        --card-text-color-main: rgba(255,255,255,0.9);
+        --card-text-color-secondary: rgba(255,205,210,0.7);
+        --card-text-color-tertiary: rgba(255,205,210,0.5);
+        --card-separator-color: rgba(255,205,210,0.12);
+    }
+}
+
+/*
+*   Article content style
+*/
+:root {
+    --blockquote-background-color: #ffe0e0;
+
+    --link-background-color: 229, 115, 115;
+
+    --pre-background-color: #fafafa;
+    --pre-text-color: #272822;
+
+    --code-background-color: rgba(0, 0, 0, 0.12);
+    --code-text-color: #808080;
+
+    --table-border-color: #e53935;
+    --tr-even-background-color: #ffe0e0;
+
+    --kbd-border-color: #e53935;
+
+    &[data-scheme="dark"] {
+        --pre-background-color: #272822;
+        --pre-text-color: #fafafa;
+        --code-background-color: #272822;
+        --code-text-color: rgba(255,255,255,0.9);
+
+        --table-border-color: #b71c1c;
+        --tr-even-background-color: #330000;
+
+        --blockquote-background-color: #330000;
+    }
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -7,7 +7,7 @@
 */
 
 @import "breakpoints.scss";
-@import "variables.scss";
+@import "palettes/{{ .Site.Params.colorPalette | default "default" }}.scss";
 @import "grid.scss";
 
 @import "external/normalize.scss";

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -57,6 +57,7 @@ params:
     featuredImageField: image
     rssFullContent: true
     favicon: # e.g.: favicon placed in `static/favicon.ico` of your site folder, then set this field to `/favicon.ico` (`/` is necessary)
+    colorPalette: "blue" # currently blue and default palettes are available
 
     footer:
         since: 2020

--- a/layouts/partials/head/style.html
+++ b/layouts/partials/head/style.html
@@ -1,3 +1,3 @@
-{{ $sass := resources.Get "scss/style.scss" }}
+{{- $sass := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . }}
 {{ $style := $sass | toCSS | minify | resources.Fingerprint "sha256" }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">

--- a/theme.toml
+++ b/theme.toml
@@ -18,6 +18,7 @@ features = [
     "darkmode",
     "table of contents",
     "search",
+    "multiple color palettes",
 ]
 
 min_version = "0.123.0"


### PR DESCRIPTION
you can see one of the palette i.e. blue palette example [here](https://amanr.me/)
you can set `colorPalette` in `params` in hugo config file to `purple`, `high-contrast`, `orange`, `red`, `green`, `blue`, or `pink`.

- green-light ![image](https://github.com/user-attachments/assets/a7e81bee-8717-40ed-98e1-cab9a4462957)
- pink-light ![image](https://github.com/user-attachments/assets/e5d8b784-4657-4e9d-a0fa-b9c0fae6ad98)
- pink-dark ![image](https://github.com/user-attachments/assets/63be66ba-de23-498e-9679-7a31599b9207)
- red-dark ![image](https://github.com/user-attachments/assets/327c8002-56cc-492b-b984-1eb21ec5fdd4)
- purple-light ![image](https://github.com/user-attachments/assets/40a1bca1-cb63-4c1d-82d5-a39b31ab3962)

