### PR TITLE
fix: Resolved an issue where certain Twikoo elements wouldn’t automatically switch colours in dark mode; updated Twikoo to version 1.6.44.

### DIFF
--- a/layouts/partials/comments/provider/twikoo.html
+++ b/layouts/partials/comments/provider/twikoo.html
@@ -1,4 +1,4 @@
-<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.39/dist/twikoo.all.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/twikoo@1.6.44/dist/twikoo.all.min.js"></script>
 <div id="tcomment"></div>
 <style>
     .twikoo {
@@ -24,8 +24,11 @@
     .twikoo .tk-preview-container,
     .twikoo .tk-content,
     .twikoo .tk-nick,
-    .twikoo .tk-send {
-        color: var(--twikoo-body-text-color-main);
+    .twikoo .tk-send,
+    .twikoo .tk-comments-no,
+    .twikoo .el-input__count,
+    .twikoo .tk-submit-action-icon {
+        color: var(--twikoo-body-text-color-main)!important;
     }
     .twikoo .el-button{
         color: var(--twikoo-body-text-color)!important;


### PR DESCRIPTION
before:

![Snipaste_2025-06-29_20-29-00](https://github.com/user-attachments/assets/1d8b3dfd-0a4c-4f1c-9561-6e431b86b17c)

after:

![Snipaste_2025-06-29_20-27-41](https://github.com/user-attachments/assets/b57a2264-aff5-4e23-b79c-df3c30689a8a)
