### PR TITLE
Add support for Mermaid diagrams in markdown content

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<pre class="mermaid">
+  {{ .Inner | htmlEscape | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,6 +23,15 @@
                 {{- block "main" . }}{{- end }}
             </main>
         </div>
+        {{ if .Store.Get "hasMermaid" }}
+          <script type="module">
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+            mermaid.initialize({
+              startOnLoad: true,
+              theme: 'neutral',
+            });
+          </script>
+        {{ end }}
         {{ partial "footer/include.html" . }}
     </body>
 </html>


### PR DESCRIPTION
## Add Mermaid Diagram Support to the Theme

This PR adds native [Mermaid](https://mermaid.js.org/) diagram rendering support to markdown content.
It allows users to include diagrams directly in code fences, e.g.:
```mermaid
graph TD
  A[Start] --> B{Is it working?}
  B -->|Yes| C[Ship it!]
  B -->|No| D[Fix it]
```

## Implementation Details

- Added a new custom renderer:
`layouts/_default/render-codeblock-mermaid.html`
This file wraps Mermaid code blocks in a `<pre class="mermaid">` tag and sets a flag (`hasMermaid`) on the page context.

- Updated `baseof.html` to conditionally include the Mermaid JavaScript module from the CDN only when needed:
```
{{ if .Store.Get "hasMermaid" }}
  <script type="module">
    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
    mermaid.initialize({
      startOnLoad: true,
      theme: 'neutral',
    });
  </script>
{{ end }}
```

## Benefits

- No external preprocessing or shortcodes required.
- Lightweight and only loaded when a page actually includes Mermaid diagrams.
- Works seamlessly with existing markdown content and Hugo’s markup system.
