### PR TITLE
Enhance text rendering with autospace properties

### DIFF
--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -12,9 +12,9 @@ body {
     margin: 0;
     font-family: var(--base-font-family);
     font-size: 1.6rem;
-    -ms-text-autospace: ideograph-alpha ideograph-numeric;
-    text-autospace: ideograph-alpha ideograph-numeric;
-    text-spacing-trim: trim-start;
+    text-autospace: ideograph-alpha ideograph-numeric punctuation insert;
+    text-spacing-trim: trim-start allow-end;
+    -ms-text-autospace: ideograph-alpha;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Enabled automatic spacing between CJK and Latin characters and trimmed leading punctuation spacing by adding text-autospace (including legacy -ms- fallback) and text-spacing-trim to the global body styles.