### PR TITLE
fix(i18n): category widget title in ru.yaml

### DIFF
--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -47,6 +47,9 @@ widget:
     tagCloud:
         title:
             other: Теги
+    categoriesCloud:
+        title:
+            other: Категории
 
 search:
     title:


### PR DESCRIPTION
The title for the categories widget was missing.

<img width="288" height="285" alt="image" src="https://github.com/user-attachments/assets/fc4a2b59-5f0a-4143-8c34-6a2e3bc41951" />
