### PR TITLE
fix(theme): Adjust Cusdis widget scrollbar and background to match Stack theme

### DIFF
--- a/layouts/partials/comments/provider/cusdis.html
+++ b/layouts/partials/comments/provider/cusdis.html
@@ -7,9 +7,8 @@
     function setCusdisTheme(theme) {
         let cusdis = document.querySelector('#cusdis_thread iframe');
         if (cusdis) {
-            window.CUSDIS.setTheme(theme)
-            let color = theme === 'dark' ? '#303030' : '#f5f5fa'
-            cusdis.contentWindow.document.body.style.backgroundColor = color
+            window.CUSDIS.setTheme(theme);
+            cusdis.contentWindow.document.body.style.backgroundColor = window.getComputedStyle(document.body).backgroundColor;
         }
     }
     window.addEventListener('load', function () {


### PR DESCRIPTION
Fix Cusdis widget scrollbar and background styling for Stack theme

**Changes made:**
- Adjusted scrollbar height to properly fit the comment content area
- Updated background color to match Stack theme's color scheme in both light and dark modes

**Visual comparison:**

| Mode | Before | After |
| :--- | :--- | :--- |
| **Light mode** | [View](https://github.com/user-attachments/assets/5286d652-9411-4136-a9f5-9a7944235d92) | [View](https://github.com/user-attachments/assets/3f6b8085-8a6c-4e14-83c6-f45e56e3319c) |
| **Dark mode** | [View](https://github.com/user-attachments/assets/870444f5-7f23-4427-ab8e-1b609b5ae3ac) | [View](https://github.com/user-attachments/assets/f67897d8-04d8-41c9-a50c-2300c2614138) |