### PR TITLE
fix: adjust padding and width for article list tiles in subsection list

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -48,10 +48,12 @@
 
 .subsection-list {
     overflow-x: auto;
+    margin-left: -24px;
 
     .article-list--tile {
         display: flex;
-        padding-bottom: 15px;
+        padding: 8px 0 34px 24px;
+        width: max-content;
 
         article {
             width: 250px;


### PR DESCRIPTION
closes https://github.com/CaiJimmy/hugo-theme-stack/issues/1093