### PR TITLE
style: remove vendor style of `<select>` in i18n switch

### DIFF
--- a/assets/scss/partials/sidebar.scss
+++ b/assets/scss/partials/sidebar.scss
@@ -190,6 +190,17 @@
         border: 0;
         background-color: transparent;
         color: var(--body-text-color);
+        padding: 0;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: inherit;
+        appearance: none;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+
+        &::-ms-expand {
+            display: none;
+        }
 
         option {
             color: var(--card-text-color-main);


### PR DESCRIPTION
This removes the annoying left padding

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/554
