### PR TITLE
fix: avoid site name appearing twice in the title

### DIFF
--- a/layouts/partials/data/title.html
+++ b/layouts/partials/data/title.html
@@ -4,17 +4,11 @@
 
 {{- $title := slice -}}
 
-{{- if $pageTitle }}
-    {{- $title = slice $pageTitle -}}
-{{- end -}}
-
 {{- if and $paginator $paginator.HasPrev -}}
     <!-- Add page number-->
     {{ $title = $title | append (printf "Page %d" $paginator.PageNumber) }}
-{{- end -}} 
-
-{{- if not .IsPage -}}
-    {{ $title = $title | append $siteTitle }}
 {{- end -}}
+
+{{- $title = $title | append (default $siteTitle $pageTitle) -}}
 
 {{ return delimit $title " - " }}


### PR DESCRIPTION
This would happen if no `_index.md` is present in `/content`. That would make `.IsPage` false, and append twice the `$siteTitle` (equal to `.Title` by default)