### PR TITLE
refactor: get favicon from assets folder

### DIFF
--- a/demo/config/_default/params.toml
+++ b/demo/config/_default/params.toml
@@ -1,6 +1,6 @@
 mainSections   = ["post"]
 rssFullContent = true
-favicon        = ""
+favicon        = "img/avatar.png"
 
 [footer]
     since = 2020

--- a/layouts/_partials/head/head.html
+++ b/layouts/_partials/head/head.html
@@ -19,7 +19,8 @@
 {{- end -}}
 
 {{ with .Site.Params.favicon }}
-    <link rel="shortcut icon" href="{{ . | relURL }}" />
+    {{- $favicon := partial "helper/image" (dict "Image" . "Resources" resources) -}}
+    <link rel="shortcut icon" href="{{ $favicon.Permalink }}" />
 {{ end }}
 
 {{- partial "google_analytics.html" . -}}


### PR DESCRIPTION
This avoid problems with relative permalink when site is placed in subfolder. 

Avoids confusion like https://github.com/CaiJimmy/hugo-theme-stack-starter/issues/61
