### PR TITLE
fix: set width of left and right sidebars to 100%

### DIFF
--- a/assets/scss/grid.scss
+++ b/assets/scss/grid.scss
@@ -4,11 +4,13 @@
 
     .left-sidebar {
         order: -3;
+        width: 100%;
         max-width: var(--left-sidebar-max-width);
     }
 
     .right-sidebar {
         order: -1;
+        width: 100%;
         max-width: var(--right-sidebar-max-width);
 
         /// Display right sidebar when min-width: lg


### PR DESCRIPTION
This prevents the width from changing when the left or right sidebar does not have enough content to stretch to 100%.