### PR TITLE
fix: enhance image caption handling by using title attribute if available

### DIFF
--- a/assets/ts/gallery.ts
+++ b/assets/ts/gallery.ts
@@ -12,6 +12,15 @@ const wrap = (figures: HTMLElement[]) => {
     }
 }
 
+const unescapeHtml = (html: string) => {
+    /// Replace special HTML entities with their corresponding characters
+    return html.replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'");
+}
+
 export default (container: HTMLElement) => {
     /// The process of wrapping image with figure tag is done using JavaScript instead of only Hugo markdown render hook
     /// because it can not detect whether image is being wrapped by a link or not
@@ -64,10 +73,13 @@ export default (container: HTMLElement) => {
         figure.appendChild(el);
 
         /// Add figcaption if it exists
-        const caption = img.getAttribute('title') || img.getAttribute('alt');
+        let caption = img.getAttribute('alt');
+        if (img.getAttribute('data-title-escaped')) {
+            caption = unescapeHtml(img.getAttribute('data-title-escaped')!);
+        }
         if (caption) {
             const figcaption = document.createElement('figcaption');
-            figcaption.innerText = caption;
+            figcaption.innerHTML = caption;
             figure.appendChild(figcaption);
         }
     }

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -1,6 +1,6 @@
 {{- $image := partial "helper/image" (dict "Resources" .Page.Resources "Image" .Destination) -}}
 {{- $alt := .PlainText | safeHTML -}}
-{{- $title := .Title -}}
+{{- $title := .Title | markdownify -}}
 
 {{/* SVG and external images won't work with gallery layout, because their width and height attributes are unknown */}}
 {{- $galleryImage := and $image.Height $image.Width -}}
@@ -14,6 +14,7 @@
 	{{ end }}
     {{ with $title }}
         title="{{ . }}"
+        data-title-escaped="{{ . | htmlEscape }}"
     {{ end }}
 	{{ if $galleryImage }}
 		class="gallery-image" 


### PR DESCRIPTION
Based on https://github.com/CaiJimmy/hugo-theme-stack/pull/1107, but we don't need to create figcaption manually as it's handled by gallery.ts

closes https://github.com/CaiJimmy/hugo-theme-stack/pull/1107