### PR TITLE
fix: handle SVG and non-image resources in image helper and tile template

### DIFF
--- a/layouts/_partials/article-list/tile.html
+++ b/layouts/_partials/article-list/tile.html
@@ -10,11 +10,14 @@
 
         <div class="article-details"
             {{- if and $image $image.Resource -}}
-                {{- $colors := $image.Resource.Colors -}}
-                {{- if $colors -}}
-                    {{- $vibrant := index $colors 0 -}}
-                    {{- $darkMuted := index $colors 1 | default $vibrant -}}
-                    style="background: linear-gradient(0deg, {{ $darkMuted }}80 0%, {{ $vibrant }}C0 100%);"
+                {{- $isSVG := eq $image.Resource.MediaType.SubType "svg" -}}
+                {{- if not $isSVG -}}
+                    {{- $colors := $image.Resource.Colors -}}
+                    {{- if $colors -}}
+                        {{- $vibrant := index $colors 0 -}}
+                        {{- $darkMuted := index $colors 1 | default $vibrant -}}
+                        style="background: linear-gradient(0deg, {{ $darkMuted }}80 0%, {{ $vibrant }}C0 100%);"
+                    {{- end -}}
                 {{- end -}}
             {{- end -}}
         >

--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -29,8 +29,9 @@
     {{ end }}
 
     {{ if $resource }}
-        {{- $isSVG := eq $resource.MediaType.SubType "svg"  -}}
-        {{- if $isSVG -}}
+        {{- $isSVG := eq $resource.MediaType.SubType "svg" -}}
+        {{- $isImage := strings.HasPrefix $resource.MediaType.Type "image" -}}
+        {{- if or $isSVG (not $isImage) -}}
             {{ $result = dict
                 "Local" true
                 "Resource" $resource
@@ -38,7 +39,7 @@
                 "Height" nil
                 "Width" nil
             }}
-        {{- else -}}            
+        {{- else -}}
             {{- $result = dict
                 "Local" true
                 "Resource" $resource


### PR DESCRIPTION
## Summary

- **`helper/image.html`**: `.Resources.Get` can return non-image resources (e.g. PDFs, text files in page bundles). Calling `.Height`/`.Width` on these causes a build error: `this method is only available for image resources`. Added an `isImage` media type check so non-image resources get `nil` Height/Width, same as SVGs.
- **`article-list/tile.html`**: `.Colors` is called on any image resource, but it's not available on SVGs, causing: `this method is only available for raster images`. Added an SVG subtype check before the `.Colors` call.

## How to reproduce

1. Create a page bundle with a non-image file (e.g. a PDF) that shares a name with the `image` front matter field, or use an SVG as a featured image
2. Run `hugo build`
3. Build fails with one of the above errors

## Test plan

- [ ] Build succeeds with SVG featured images on archive/taxonomy pages (tile layout)
- [ ] Build succeeds with page bundles containing non-image resources
- [ ] Raster images still get correct Width/Height and gradient colors