### PR TITLE
feat(widgets): link widget titles to their respective pages

### DIFF
--- a/layouts/_partials/widget/archives.html
+++ b/layouts/_partials/widget/archives.html
@@ -7,7 +7,11 @@
         <div class="widget-icon">
             {{ partial "helper/icon" "infinity" }}
         </div>
-        <h2 class="widget-title section-title">{{ T "widget.archives.title" }}</h2>
+        <h2 class="widget-title section-title">
+            <a href="{{ $archivesPage.RelPermalink }}">
+                {{ T "widget.archives.title" }}
+            </a>
+        </h2>
 
         {{ $pages := partial "helper/pages.html" $context.Site.Home }}
         {{ $archives := $pages.GroupByDate "2006" }}

--- a/layouts/_partials/widget/taxonomy.html
+++ b/layouts/_partials/widget/taxonomy.html
@@ -13,7 +13,7 @@
 {{- $widgetTitle := .Params.title -}}
 {{- $limit := default 10 .Params.limit -}}
 {{- $icon := default .Params.taxonomy .Params.icon -}}
-{{- $showLink := default false .Params.showLink -}}
+{{- $showLink := default true .Params.showLink -}}
 
 <section class="widget tagCloud">
     <div class="widget-icon">


### PR DESCRIPTION
## Summary

- **`archives.html`**: The archives widget title is now linked to the archives page, consistent with how individual year entries already link there
- **`taxonomy.html`**: Changed `showLink` default from `false` to `true` so tag-cloud and categories widget titles link to their taxonomy listing pages by default

## Motivation

Widget titles are the primary UI element users see, but currently they're plain text while the content below them links to pages. Linking the titles improves navigation — clicking "Tags" takes you to the full tags listing, clicking "Archives" takes you to the full archives page.

The `showLink` parameter was already implemented in `taxonomy.html` but defaulted to `false`. This changes the default to `true` while preserving the ability to disable it via `showLink = false` in widget params.

## Test plan

- [ ] Tag-cloud widget title links to `/tags/`
- [ ] Categories widget title links to `/categories/`
- [ ] Archives widget title links to the archives page
- [ ] Setting `showLink = false` in widget params disables the link on taxonomy widgets