### PR TITLE
fix: reading time not displaying in `article/components/details` partial

### DIFF
--- a/layouts/_partials/article/components/details.html
+++ b/layouts/_partials/article/components/details.html
@@ -28,7 +28,7 @@
         {{ end }}
     </div>
 
-    {{ $showReadingTime := $Page.Params.readingTime | default (.Site.Params.article.readingTime) }}
+    {{ $showReadingTime := $Page.Params.readingTime | default ($Page.Site.Params.article.readingTime) }}
     {{ $showDate := not $Page.Date.IsZero }}
     {{ $showFooter := or $showDate $showReadingTime }}
     {{ if $showFooter }}


### PR DESCRIPTION
## Summary

- Fix `.Site.Params.article.readingTime` resolving to nil in `details.html` because the partial receives a dict context, not a page context
- Change to `$Page.Site.Params.article.readingTime` to match the pattern already used on lines 40 and 67 of the same file

## Problem

The `details.html` partial is called with a dict:
```go
{{ partial "article/components/details" (dict "Page" $Page "IsList" $IsList) }}
```

When `.` (dot) is a dict, `.Site` resolves to nil. This causes `$showReadingTime` to always be false, so the reading time is never rendered despite `readingTime = true` being set in site config.

Lines 40 and 67 of the same file already correctly use `$Page.Site.Params` — only line 31 was missed.

## Test plan

- [ ] Verify `readingTime = true` in `params.toml` under `[article]`
- [ ] Build site and confirm `<time class="article-time--reading">` appears in article HTML
- [ ] Confirm reading time displays on both list and single page views