### PR TITLE
fix: use IsImageResourceWithMeta to check whether image has width / height attributes

### DIFF
--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -33,7 +33,7 @@
     {{ end }}
 
     {{ with $resource }}
-        {{ if reflect.IsImageResourceProcessable . }}
+        {{ if reflect.IsImageResourceWithMeta . }}
             {{ $result = dict
                 "Resource" $resource
                 "Permalink" $permalink


### PR DESCRIPTION
See https://gohugo.io/functions/reflect/isimageresourcewithmeta/

Condition `IsImageResourceProcessable` was too strong