### PR TITLE
feat: use `images.AutoOrient` in `helper/image`

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -76,6 +76,8 @@ SortBy             = "default"
     default = "auto"
 
 [imageProcessing]
+    autoOrient = false
+
     [imageProcessing.content]
         widths  = [800, 1600, 2400]
         enabled = true

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -1,4 +1,4 @@
-{{- $image := partial "helper/image" (dict "Resources" .Page.Resources "Image" .Destination) -}}
+{{- $image := partial "helper/image" (dict "Resources" .Page.Resources "Image" .Destination "Context" .Page) -}}
 {{- $alt := .PlainText | safeHTML -}}
 {{- $title := .Title | markdownify -}}
 

--- a/layouts/_partials/article-list/compact.html
+++ b/layouts/_partials/article-list/compact.html
@@ -23,7 +23,7 @@
             {{- end -}}
         </div>
 
-        {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+        {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
         {{ if $image }}
         <div class="article-image">
             {{ partial "helper/thumbnail-image" (dict 

--- a/layouts/_partials/article-list/default.html
+++ b/layouts/_partials/article-list/default.html
@@ -1,4 +1,4 @@
-{{ $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) }}
+{{ $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) }}
 <article class="{{ if $image }}has-image{{ end }}">
     {{ partial "article/components/header" (dict "Page" . "IsList" true) }}
 </article>

--- a/layouts/_partials/article-list/tile.html
+++ b/layouts/_partials/article-list/tile.html
@@ -1,4 +1,4 @@
-{{ $image := partial "helper/image" (dict "Image" .context.Params.image "Resources" .context.Resources) }}
+{{ $image := partial "helper/image" (dict "Image" .context.Params.image "Resources" .context.Resources "Context" .context) }}
 <article class="{{ if $image }}has-image{{ end }}">
     <a href="{{ .context.RelPermalink }}">
         {{ if $image }}

--- a/layouts/_partials/article/components/header.html
+++ b/layouts/_partials/article/components/header.html
@@ -1,7 +1,7 @@
 {{- $IsList := .IsList -}}
 {{- $Page := .Page -}}
 <header class="article-header">
-    {{- $image := partial "helper/image" (dict "Image" $Page.Params.image "Resources" $Page.Resources) -}}
+    {{- $image := partial "helper/image" (dict "Image" $Page.Params.image "Resources" $Page.Resources "Context" $Page) -}}
     {{ if $image }}
     <div class="article-image">
         <a href="{{ $Page.RelPermalink }}">

--- a/layouts/_partials/article/components/links.html
+++ b/layouts/_partials/article/components/links.html
@@ -15,7 +15,7 @@
                     </footer>
                 </div>
 
-                {{- $image := partial "helper/image" (dict "Image" $link.image "Resources" $.Resources) -}}
+                {{- $image := partial "helper/image" (dict "Image" $link.image "Resources" $.Resources "Context" .) -}}
                 {{- with $image -}}
                     <div class="article-image">
                        {{ partial "helper/thumbnail-image" (dict 

--- a/layouts/_partials/head/head.html
+++ b/layouts/_partials/head/head.html
@@ -23,7 +23,7 @@
     <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{- end -}}
 
-{{- $favicon := partial "helper/image" (dict "Image" .Site.Params.favicon "Resources" resources) -}}
+{{- $favicon := partial "helper/image" (dict "Image" .Site.Params.favicon "Resources" resources "Context" .) -}}
 {{ with $favicon }}
     <link rel="shortcut icon" href="{{ .Permalink }}" />
 {{ end }}

--- a/layouts/_partials/head/opengraph/provider/base.html
+++ b/layouts/_partials/head/opengraph/provider/base.html
@@ -37,7 +37,7 @@
     {{- end -}}
 {{- end -}}
 
-{{ $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) }}
+{{ $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) }}
 {{- if $image -}}
     <meta property='og:image' content='{{ absURL $image.permalink }}' />
 {{- end -}}

--- a/layouts/_partials/head/opengraph/provider/twitter.html
+++ b/layouts/_partials/head/opengraph/provider/twitter.html
@@ -9,7 +9,7 @@
 <meta name="twitter:title" {{ printf "content=%q" $title | safeHTMLAttr }}>
 <meta name="twitter:description" {{ printf "content=%q" $description | safeHTMLAttr }}>
 
-{{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+{{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
 {{- if $image -}}
     <meta name="twitter:card" content="{{ .Site.Params.opengraph.twitter.card }}">
     <meta name="twitter:image" content='{{ absURL $image.permalink }}' />

--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -1,6 +1,7 @@
 /// Params:
 ///     Resources: Where to search for images
 ///     Image: Image URL
+///     Context: page context (used to access the configuration)
 
 /// Returns:
 ///     Resource: Hugo image resource object
@@ -35,7 +36,7 @@
     {{ end }}
 
     {{ if $resource }}
-        {{ if reflect.IsImageResourceProcessable $resource }}
+        {{ if and .Context.Site.Params.imageProcessing.autoOrient (reflect.IsImageResourceProcessable $resource) }}
             {{ $filter := images.AutoOrient }}
             {{ $resource = $resource | images.Filter $filter }}
             {{ if $local }}

--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -32,8 +32,10 @@
         {{ end }}   
     {{ end }}
 
-    {{ with $resource }}
-        {{ if reflect.IsImageResourceWithMeta . }}
+    {{ if $resource }}
+        {{ $filter := images.AutoOrient }}
+        {{ $resource = $resource | images.Filter $filter }}
+        {{ if reflect.IsImageResourceWithMeta $resource }}
             {{ $result = dict
                 "Resource" $resource
                 "Permalink" $permalink

--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -14,6 +14,7 @@
     {{ $url := urls.Parse .Image }}
     {{ $permalink := .Image }}
     {{ $resource := "" }}
+    {{ $local := true }}
 
     {{ if not (in (slice "https" "http") $url.Scheme) }}
         {{/* Local image */}}
@@ -26,6 +27,7 @@
                 {{ errorf "%s" . }}
             {{ else with .Value }}
                 {{ $resource = . }}
+                {{ $local = false }}
             {{ else }}
                 {{ errorf "Unable to get remote resource %q" $url }}
             {{ end }}
@@ -33,14 +35,21 @@
     {{ end }}
 
     {{ if $resource }}
-        {{ $filter := images.AutoOrient }}
-        {{ $resource = $resource | images.Filter $filter }}
+        {{ if reflect.IsImageResourceProcessable $resource }}
+            {{ $filter := images.AutoOrient }}
+            {{ $resource = $resource | images.Filter $filter }}
+            {{ if $local }}
+                {{ $permalink = $resource.RelPermalink }}
+            {{ end }}
+        {{ end }}
+        
         {{ if reflect.IsImageResourceWithMeta $resource }}
             {{ $result = dict
                 "Resource" $resource
                 "Permalink" $permalink
                 "Height" $resource.Height
                 "Width" $resource.Width
+                "Local" $local
             }}
         {{ else }}
             {{ $result = dict

--- a/layouts/_partials/helper/image.html
+++ b/layouts/_partials/helper/image.html
@@ -49,7 +49,6 @@
                 "Permalink" $permalink
                 "Height" $resource.Height
                 "Width" $resource.Width
-                "Local" $local
             }}
         {{ else }}
             {{ $result = dict

--- a/layouts/_partials/sidebar/left.html
+++ b/layouts/_partials/sidebar/left.html
@@ -7,7 +7,7 @@
 
     <header>
         {{ with .Site.Params.sidebar.avatar }}
-            {{- $avatar := partial "helper/image" (dict "Image" . "Resources" resources) -}}
+            {{- $avatar := partial "helper/image" (dict "Image" . "Resources" resources "Context" $) -}}
             <figure class="site-avatar">
                 <a href="{{ $.Site.Home.RelPermalink }}">
                     <img src="{{ $avatar.Permalink }}" 

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -17,7 +17,7 @@
                 {{ end }}
             </div>
     
-            {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+            {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
             {{ if $image }}
                 <div class="section-image">
                     {{ partial "helper/thumbnail-image" (dict 

--- a/layouts/page/search.json
+++ b/layouts/page/search.json
@@ -4,7 +4,7 @@
 {{- range $pages -}}
     {{- $data := dict "title" .Title "date" .Date "permalink" .RelPermalink "content" (.Plain) -}}
 
-    {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+    {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
     {{- if $image -}}
         {{- $data = merge $data (dict "image" $image.Permalink) -}}
     {{- end -}}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -50,7 +50,7 @@
                 {{- if .Site.Params.RSSFullContent -}}
                     {{- $content = .Content -}}
                 {{- end -}}
-                {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources) -}}
+                {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
                 {{- if $image -}}
                     {{- $imgTag := printf "<img src=\"%s\" alt=\"Featured image of post %s\" />" ($image.permalink | absURL) .Title -}}
                     {{- $content = printf "%s%s" $imgTag $content -}}


### PR DESCRIPTION
Configurable via `.Site.Params.imageProcessing.autoOrient`

Disabled by default, because it will generate a new version of image regardless if the image has changed orientation.

closes https://github.com/CaiJimmy/hugo-theme-stack/issues/1292