### PR TITLE
fix: do not display the date of term pages

### DIFF
--- a/layouts/_partials/article-list/compact.html
+++ b/layouts/_partials/article-list/compact.html
@@ -11,14 +11,18 @@
                 {{- $description = $description | default (T "list.page" (len .Pages)) -}}
             {{- end -}}
             {{- if or $description (not .Date.IsZero) -}}
+                {{/* 
+                    If it's a term, the date is extracted from the first page of the collection, which is not very useful.
+                    In that case, we prefer to display the description (if set), or the number of pages within the collection.
+                */}}
                 <footer class="article-meta">
-                    {{- if not .Date.IsZero -}}
+                    {{- if or $IsTerm .Date.IsZero -}}
+                        <span class="article-description">{{- $description -}}</span>
+                    {{- else if not .Date.IsZero -}}
                         <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
                             {{- .Date | time.Format .Site.Params.dateFormat.published -}}
                         </time>
-                    {{- else if $description -}}
-                        <span class="article-description">{{- $description -}}</span>
-                    {{ end }}
+                    {{- end }}
                 </footer>
             {{- end -}}
         </div>


### PR DESCRIPTION
<img width="875" height="562" alt="image" src="https://github.com/user-attachments/assets/293fc5b7-2f5c-4d57-9ccc-654f11538c8e" />

Now it would show the description or fallback content (number of pages within the collection)