### PR TITLE
refactor: remove custom scrollbar styles and related variables

### DIFF
--- a/assets/scss/partials/base.scss
+++ b/assets/scss/partials/base.scss
@@ -1,6 +1,7 @@
 html {
     font-size: 62.5%;
     overflow-y: scroll;
+    scrollbar-gutter: stable;
 }
 
 * {
@@ -18,24 +19,3 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
-
-/* scrollbar styles for Firefox */
-* {
-    scrollbar-width: auto;
-    scrollbar-color: var(--scrollbar-thumb) transparent;
-}
-/**/
-
-/* scrollbar styles for Chromium */
-::-webkit-scrollbar {
-    height: auto;
-}
-
-::-webkit-scrollbar-thumb {
-    background-color: var(--scrollbar-thumb);
-}
-
-::-webkit-scrollbar-track {
-    background-color: transparent;
-}
-/**/

--- a/assets/scss/partials/layout/article.scss
+++ b/assets/scss/partials/layout/article.scss
@@ -133,10 +133,6 @@
     display: flex;
     flex-direction: column;
     color: var(--card-text-color-main);
-
-    ::-webkit-scrollbar-thumb {
-        background-color: var(--card-separator-color);
-    }
 }
 
 .widget--toc {

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -19,17 +19,12 @@
 
     --section-separation: 40px;
 
-    --scrollbar-thumb: hsl(0, 0%, 85%);
-    --scrollbar-track: var(--body-background);
-
     &[data-scheme="dark"] {
         --body-background: #303030;
         --accent-color: #ecf0f1;
         --accent-color-darker: #bdc3c7;
         --accent-color-text: #000;
         --body-text-color: rgba(255, 255, 255, 0.7);
-        --scrollbar-thumb: hsl(0, 0%, 40%);
-        --scrollbar-track: var(--body-background);
     }
 }
 


### PR DESCRIPTION
In macOS the style is just awful, and probably it's better to let the browser use the own styling as this does not give any significant benefit.

<img width="2032" height="1312" alt="image" src="https://github.com/user-attachments/assets/13d91d65-e8c0-4f9b-a3bb-bacc756aa979" />


