### PR TITLE
fix: related content overflow and horizontal scroll issues

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -56,15 +56,32 @@
 
     /// These values are computed from the shadow of the article-list--tile (which uses shadow-l1 and shadow-l2)
     /// so that the shadow is not cut off, while staying within the viewport on small screens.
-    margin-left: calc(var(--overlap-x) * -1);
+    /// The left margin expands to the full shadow width to align the card to the main article,
+    /// while the right margin is clamped to prevent page overflow.
+    margin-left: calc(var(--shadow-overlap-x) * -1);
     margin-right: calc(var(--overlap-x) * -1);
     margin-bottom: calc(var(--shadow-overlap-y) * -1);
+
+    /// Smooth fade out for the right edge to avoid a hard cut where the shadow is clamped.
+    -webkit-mask-image: linear-gradient(to left, transparent 0%, black 80px);
+    mask-image: linear-gradient(to left, transparent 0%, black 80px);
+
+    [dir="rtl"] & {
+        margin-left: calc(var(--overlap-x) * -1);
+        margin-right: calc(var(--shadow-overlap-x) * -1);
+        -webkit-mask-image: linear-gradient(to right, transparent 0%, black 80px);
+        mask-image: linear-gradient(to right, transparent 0%, black 80px);
+    }
     
     .article-list--tile {
         display: flex;
-        padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);
+        padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--shadow-overlap-x);
         width: max-content;
         gap: var(--spacing-lg);
+
+        [dir="rtl"] & {
+            padding: var(--spacing-xs) var(--shadow-overlap-x) var(--shadow-overlap-y) var(--overlap-x);
+        }
 
         article {
             flex-shrink: 0;

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -44,9 +44,17 @@
     }
 }
 
+@property --left-edge-fade-size {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+}
+
 .subsection-list {
     --shadow-overlap-x: calc(var(--shadow-l2-blur) + 4px);
     --shadow-overlap-y: calc(var(--shadow-l2-blur) + var(--shadow-l2-y) + 4px);
+    --edge-fade-size: 40px;
+    --left-edge-fade-size: 0px;
 
     overflow-x: auto;
 
@@ -56,31 +64,45 @@
 
     /// These values are computed from the shadow of the article-list--tile (which uses shadow-l1 and shadow-l2)
     /// so that the shadow is not cut off, while staying within the viewport on small screens.
-    /// The left margin expands to the full shadow width to align the card to the main article,
-    /// while the right margin is clamped to prevent page overflow.
-    margin-left: calc(var(--shadow-overlap-x) * -1);
+    /// Clamp both sides to prevent page-level horizontal overflow.
+    margin-left: calc(var(--overlap-x) * -1);
     margin-right: calc(var(--overlap-x) * -1);
     margin-bottom: calc(var(--shadow-overlap-y) * -1);
 
-    /// Smooth fade out for the right edge to avoid a hard cut where the shadow is clamped.
-    -webkit-mask-image: linear-gradient(to left, transparent 0%, black 80px);
-    mask-image: linear-gradient(to left, transparent 0%, black 80px);
+    /// Smooth fade on both horizontal edges to avoid hard cuts where shadows are clamped.
+    --subsection-mask-image: linear-gradient(
+        to right,
+        transparent 0%,
+        rgb(0 0 0 / 0.12) calc(var(--left-edge-fade-size) * 0.2),
+        rgb(0 0 0 / 0.45) calc(var(--left-edge-fade-size) * 0.55),
+        black var(--left-edge-fade-size),
+        black calc(100% - var(--edge-fade-size)),
+        rgb(0 0 0 / 0.45) calc(100% - (var(--edge-fade-size) * 0.55)),
+        rgb(0 0 0 / 0.12) calc(100% - (var(--edge-fade-size) * 0.2)),
+        transparent 100%
+    );
+    -webkit-mask-image: var(--subsection-mask-image);
+    mask-image: var(--subsection-mask-image);
+
+    // CSS-only: left fade ramps in quickly once horizontal scrolling starts.
+    animation: subsection-left-fade linear both;
+    animation-timeline: scroll(self inline);
+    animation-range: 1px 24px;
+    animation-timing-function: ease-out;
 
     [dir="rtl"] & {
         margin-left: calc(var(--overlap-x) * -1);
-        margin-right: calc(var(--shadow-overlap-x) * -1);
-        -webkit-mask-image: linear-gradient(to right, transparent 0%, black 80px);
-        mask-image: linear-gradient(to right, transparent 0%, black 80px);
+        margin-right: calc(var(--overlap-x) * -1);
     }
     
     .article-list--tile {
         display: flex;
-        padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--shadow-overlap-x);
+        padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);
         width: max-content;
         gap: var(--spacing-lg);
 
         [dir="rtl"] & {
-            padding: var(--spacing-xs) var(--shadow-overlap-x) var(--shadow-overlap-y) var(--overlap-x);
+            padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);
         }
 
         article {
@@ -95,5 +117,14 @@
                 padding: var(--spacing-lg);
             }
         }
+    }
+}
+
+@keyframes subsection-left-fade {
+    from {
+        --left-edge-fade-size: 0px;
+    }
+    to {
+        --left-edge-fade-size: var(--edge-fade-size);
     }
 }

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -50,11 +50,18 @@
     initial-value: 0px;
 }
 
+@property --right-edge-fade-size {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 64px;
+}
+
 .subsection-list {
     --shadow-overlap-x: calc(var(--shadow-l2-blur) + 4px);
     --shadow-overlap-y: calc(var(--shadow-l2-blur) + var(--shadow-l2-y) + 4px);
-    --edge-fade-size: 40px;
+    --edge-fade-size: 64px;
     --left-edge-fade-size: 0px;
+    --right-edge-fade-size: var(--edge-fade-size);
 
     overflow-x: auto;
 
@@ -73,22 +80,27 @@
     --subsection-mask-image: linear-gradient(
         to right,
         transparent 0%,
-        rgb(0 0 0 / 0.12) calc(var(--left-edge-fade-size) * 0.2),
-        rgb(0 0 0 / 0.45) calc(var(--left-edge-fade-size) * 0.55),
+        rgb(0 0 0 / 0.06) calc(var(--left-edge-fade-size) * 0.12),
+        rgb(0 0 0 / 0.2) calc(var(--left-edge-fade-size) * 0.3),
+        rgb(0 0 0 / 0.45) calc(var(--left-edge-fade-size) * 0.52),
+        rgb(0 0 0 / 0.72) calc(var(--left-edge-fade-size) * 0.76),
         black var(--left-edge-fade-size),
-        black calc(100% - var(--edge-fade-size)),
-        rgb(0 0 0 / 0.45) calc(100% - (var(--edge-fade-size) * 0.55)),
-        rgb(0 0 0 / 0.12) calc(100% - (var(--edge-fade-size) * 0.2)),
+        black calc(100% - var(--right-edge-fade-size)),
+        rgb(0 0 0 / 0.72) calc(100% - (var(--right-edge-fade-size) * 0.76)),
+        rgb(0 0 0 / 0.45) calc(100% - (var(--right-edge-fade-size) * 0.52)),
+        rgb(0 0 0 / 0.2) calc(100% - (var(--right-edge-fade-size) * 0.3)),
+        rgb(0 0 0 / 0.06) calc(100% - (var(--right-edge-fade-size) * 0.12)),
         transparent 100%
     );
     -webkit-mask-image: var(--subsection-mask-image);
     mask-image: var(--subsection-mask-image);
 
-    // CSS-only: left fade ramps in quickly once horizontal scrolling starts.
-    animation: subsection-left-fade linear both;
+    // CSS-only: left fade ramps in quickly once horizontal scrolling starts,
+    // and right fade turns off near the end of horizontal scroll.
+    animation: subsection-left-fade linear both, subsection-right-fade linear both;
     animation-timeline: scroll(self inline);
-    animation-range: 1px 24px;
-    animation-timing-function: ease-out;
+    animation-range: 1px 24px, 0% 100%;
+    animation-timing-function: ease-out, linear;
 
     [dir="rtl"] & {
         margin-left: calc(var(--overlap-x) * -1);
@@ -126,5 +138,15 @@
     }
     to {
         --left-edge-fade-size: var(--edge-fade-size);
+    }
+}
+
+@keyframes subsection-right-fade {
+    0%,
+    92% {
+        --right-edge-fade-size: var(--edge-fade-size);
+    }
+    100% {
+        --right-edge-fade-size: 0px;
     }
 }

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -52,13 +52,13 @@
 
     /// These values are computed from the shadow of the article-list--tile (which uses shadow-l1 and shadow-l2)
     /// so that the shadow is not cut off
-    margin-left: calc(var(--shadow-overlap-x) * -1);
-    margin-right: calc(var(--shadow-overlap-x) * -1);
+    margin-left: 0;
+    margin-right: 0;
     margin-bottom: calc(var(--shadow-overlap-y) * -1);
-    
+
     .article-list--tile {
         display: flex;
-        padding: var(--spacing-xs) var(--shadow-overlap-x) var(--shadow-overlap-y) var(--shadow-overlap-x);
+        padding: var(--spacing-xs) 0 var(--shadow-overlap-y) 0;
         width: max-content;
         gap: var(--spacing-lg);
 

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -50,15 +50,19 @@
 
     overflow-x: auto;
 
-    /// These values are computed from the shadow of the article-list--tile (which uses shadow-l1 and shadow-l2)
-    /// so that the shadow is not cut off
-    margin-left: 0;
-    margin-right: 0;
-    margin-bottom: calc(var(--shadow-overlap-y) * -1);
+    /// Limit the horizontal overlap to the container padding to prevent page overflow on mobile.
+    /// On desktop, it still allows the full shadow to be visible.
+    --overlap-x: min(var(--shadow-overlap-x), var(--container-padding));
 
+    /// These values are computed from the shadow of the article-list--tile (which uses shadow-l1 and shadow-l2)
+    /// so that the shadow is not cut off, while staying within the viewport on small screens.
+    margin-left: calc(var(--overlap-x) * -1);
+    margin-right: calc(var(--overlap-x) * -1);
+    margin-bottom: calc(var(--shadow-overlap-y) * -1);
+    
     .article-list--tile {
         display: flex;
-        padding: var(--spacing-xs) 0 var(--shadow-overlap-y) 0;
+        padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);
         width: max-content;
         gap: var(--spacing-lg);
 


### PR DESCRIPTION
This pull request improves the responsive styling of the article list layout to prevent horizontal overflow on mobile devices. The changes ensure that the box shadow and padding do not extend beyond the container's padding on smaller screens, while still displaying the full shadow effect on desktop.

Layout and responsive design improvements:

* Introduced a new CSS variable `--overlap-x` in `list.scss` to limit horizontal overlap to the container padding, preventing page overflow on mobile while preserving the full shadow on desktop.
* Updated the `margin-left`, `margin-right`, and `.article-list--tile` padding calculations to use `--overlap-x` instead of `--shadow-overlap-x`, ensuring shadows and content stay within the viewport on small screens.

before:
<img width="488" height="1060" alt="图片" src="https://github.com/user-attachments/assets/a632d399-7050-4b0a-b194-efaacfe19d7a" />
after:
<img width="488" height="1055" alt="Snipaste_2026-03-11_16-03-22" src="https://github.com/user-attachments/assets/0b23531e-f95b-4c53-b1b3-2ad20ed1f156" />

