### PR TITLE
fix: optimize code block selection experience

### DIFF
--- a/assets/scss/partials/highlight/common.scss
+++ b/assets/scss/partials/highlight/common.scss
@@ -52,10 +52,16 @@
 
 /* LineNumbersTable */
 .chroma .lnt {
-    margin-right: 0.4em;
+    margin-right: 0;
+    user-select: none;
     padding: 0 0.4em 0 0.4em;
     color: #7f7f7f;
     display: block;
+}
+
+/* Optimise code block selection experience */
+span.line {
+    margin-left: 0.4em;
 }
 
 /* LineNumbers */


### PR DESCRIPTION
This pull request makes minor improvements to the styling of code blocks, specifically focusing on the line number display and code block selection experience.

* Line number styling: Removes the right margin for `.chroma .lnt`, adds `user-select: none` to prevent accidental selection of line numbers, and adjusts padding for better appearance.
* Code block selection: Adds a left margin to `span.line` to optimize the code block selection experience.

Line numbers used to be selectable:
<img width="1024" height="550" alt="Snipaste_2026-03-13_13-21-12" src="https://github.com/user-attachments/assets/9d38a7a2-cd7a-48ad-9b53-f5de4129c8e8" />

Now they are not:
<img width="1027" height="526" alt="Snipaste_2026-03-13_13-20-34" src="https://github.com/user-attachments/assets/00106715-7344-45e4-b9f8-6419e81ee86e" />
