### PR TITLE
fix: ensure taxonomy widget title is only linked if a taxonomy page exits

### DIFF
--- a/layouts/_partials/widget/taxonomy.html
+++ b/layouts/_partials/widget/taxonomy.html
@@ -20,7 +20,7 @@
         {{ partial "helper/icon" $icon }}
     </div>
     <h2 class="widget-title section-title">
-        {{ if $showLink }}
+        {{ if and $showLink $taxonomyPage }}
             <a href="{{ $taxonomyPage.RelPermalink }}">
                 {{ $widgetTitle }}
             </a>


### PR DESCRIPTION
Otherwise if the site is empty, an error will appear.

closes https://github.com/CaiJimmy/hugo-theme-stack-starter/issues/90