### PR TITLE
fix: replace deprecated `.Site.Data` with `hugo.Data`

### DIFF
--- a/layouts/_partials/article/components/photoswipe.html
+++ b/layouts/_partials/article/components/photoswipe.html
@@ -1,9 +1,9 @@
 {{- $opts := dict "minify" hugo.IsProduction "format" "esm" -}}
 {{- $galleryScript := resources.Get "ts/gallery.ts" | js.Build $opts -}}
 
-{{ $style := .Site.Data.external.PhotoSwipe.Style }}
-{{ $core := .Site.Data.external.PhotoSwipe.Core }}
-{{ $lightbox := .Site.Data.external.PhotoSwipe.Lightbox }}
+{{ $style := hugo.Data.external.PhotoSwipe.Style }}
+{{ $core := hugo.Data.external.PhotoSwipe.Core }}
+{{ $lightbox := hugo.Data.external.PhotoSwipe.Lightbox }}
 
 <script type="module">
     import gallery from '{{ $galleryScript.RelPermalink }}';

--- a/layouts/_partials/helper/external.html
+++ b/layouts/_partials/helper/external.html
@@ -1,4 +1,4 @@
-{{- $List := index .Context.Site.Data.external .Namespace -}}
+{{- $List := index hugo.Data.external .Namespace -}}
 {{- with $List -}}
     {{- range . -}}
         {{- if eq .type "script" -}}


### PR DESCRIPTION
Use hugo.Data instead of deprecated .Site.Data (Hugo v0.156.0+)