### PR TITLE
fix: correct permalink casing for OpenGraph and Twitter image tags

### DIFF
--- a/layouts/_partials/head/opengraph/provider/base.html
+++ b/layouts/_partials/head/opengraph/provider/base.html
@@ -39,5 +39,5 @@
 
 {{ $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) }}
 {{- if $image -}}
-    <meta property='og:image' content='{{ absURL $image.permalink }}' />
+    <meta property='og:image' content='{{ absURL $image.Permalink }}' />
 {{- end -}}

--- a/layouts/_partials/head/opengraph/provider/twitter.html
+++ b/layouts/_partials/head/opengraph/provider/twitter.html
@@ -12,5 +12,5 @@
 {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
 {{- if $image -}}
     <meta name="twitter:card" content="{{ .Site.Params.opengraph.twitter.card }}">
-    <meta name="twitter:image" content='{{ absURL $image.permalink }}' />
+    <meta name="twitter:image" content='{{ absURL $image.Permalink }}' />
 {{- end -}}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -52,7 +52,7 @@
                 {{- end -}}
                 {{- $image := partial "helper/image" (dict "Image" .Params.image "Resources" .Resources "Context" .) -}}
                 {{- if $image -}}
-                    {{- $imgTag := printf "<img src=\"%s\" alt=\"Featured image of post %s\" />" ($image.permalink | absURL) .Title -}}
+                    {{- $imgTag := printf "<img src=\"%s\" alt=\"Featured image of post %s\" />" ($image.Permalink | absURL) .Title -}}
                     {{- $content = printf "%s%s" $imgTag $content -}}
                 {{- end -}}
                 {{- $content | transform.XMLEscape | safeHTML -}}


### PR DESCRIPTION
Close #1323 