### PR TITLE
fix(cookies): avoid banner wrapper blocking clicks

### DIFF
--- a/assets/scss/partials/cookies.scss
+++ b/assets/scss/partials/cookies.scss
@@ -5,6 +5,7 @@
     right: 0;
     z-index: 9999;
     padding: var(--container-padding);
+    pointer-events: none;
 
     &[aria-hidden="true"] {
         display: none;
@@ -21,6 +22,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+    pointer-events: auto;
 
     @include respond(md) {
         flex-direction: row;


### PR DESCRIPTION
Currently, the wrapper of the cookie consent banner captures user clicks, making elements such as the dark mode toggle unclickable when the banner pops up.

This pull request makes a small but important update to the cookie banner's styling to improve user interaction. The main change ensures that only the visible cookie banner content is interactive, allowing users to click elements not covered by the banner.

- Accessibility and interaction improvements:
  * [`assets/scss/partials/cookies.scss`](diffhunk://#diff-6438b75862ddab01027b98d5aa4cf8039ba891ace9bde9e9d72da12fb96d4a75R8): Sets `pointer-events: none` on the cookie banner container to prevent interaction with hidden or background areas, and enables `pointer-events: auto` on the banner content so users can interact with visible elements. [[1]](diffhunk://#diff-6438b75862ddab01027b98d5aa4cf8039ba891ace9bde9e9d72da12fb96d4a75R8) [[2]](diffhunk://#diff-6438b75862ddab01027b98d5aa4cf8039ba891ace9bde9e9d72da12fb96d4a75R25)