### PR TITLE
fix: Firefox fallback breaks right-edge fade in related content

### DIFF
--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -95,6 +95,11 @@
     -webkit-mask-image: var(--subsection-mask-image);
     mask-image: var(--subsection-mask-image);
 
+    [dir="rtl"] & {
+        margin-left: calc(var(--overlap-x) * -1);
+        margin-right: calc(var(--overlap-x) * -1);
+    }
+
     .article-list--tile {
         display: flex;
         padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -95,18 +95,6 @@
     -webkit-mask-image: var(--subsection-mask-image);
     mask-image: var(--subsection-mask-image);
 
-    // CSS-only: left fade ramps in quickly once horizontal scrolling starts,
-    // and right fade turns off near the end of horizontal scroll.
-    animation: subsection-left-fade linear both, subsection-right-fade linear both;
-    animation-timeline: scroll(self inline);
-    animation-range: 1px 24px, 0% 100%;
-    animation-timing-function: ease-out, linear;
-
-    [dir="rtl"] & {
-        margin-left: calc(var(--overlap-x) * -1);
-        margin-right: calc(var(--overlap-x) * -1);
-    }
-    
     .article-list--tile {
         display: flex;
         padding: var(--spacing-xs) var(--overlap-x) var(--shadow-overlap-y) var(--overlap-x);
@@ -127,8 +115,21 @@
 
             .article-details {
                 padding: var(--spacing-lg);
-            }
-        }
+    }
+}
+
+    }
+}
+
+// Only apply scroll-driven edge fades in browsers that support scroll timelines.
+// Browsers without support (e.g. Firefox) fall back to the static right-edge fade
+// defined by the explicit CSS variable declarations above.
+@supports (animation-timeline: scroll(self inline)) {
+    .subsection-list {
+        animation: subsection-left-fade linear both, subsection-right-fade linear both;
+        animation-timeline: scroll(self inline);
+        animation-range: 1px 24px, 0% 100%;
+        animation-timing-function: ease-out, linear;
     }
 }
 

--- a/assets/scss/partials/layout/list.scss
+++ b/assets/scss/partials/layout/list.scss
@@ -115,9 +115,8 @@
 
             .article-details {
                 padding: var(--spacing-lg);
-    }
-}
-
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<img width="1189" height="780" alt="图片" src="https://github.com/user-attachments/assets/d6df2f8d-eb28-40c4-bb36-e11bc2b44613" />

Firefox does not support scroll-driven animations by default, causing the animation to fall back to a 0s time-based animation that jumps to the last keyframe — flipping the fade from right to left.

Wrap animation properties in @supports (animation-timeline: scroll()) so Firefox degrades gracefully to a static right-edge fade.