### PR TITLE
fix: Hugo language related deprecation (v0.158.0+)

### DIFF
--- a/demo/config/_default/hugo.toml
+++ b/demo/config/_default/hugo.toml
@@ -1,5 +1,5 @@
 baseURL                = "https://demo.stack.cai.im/"
-languageCode           = "en-us"
+locale                 = "en-us"
 title                  = "Hugo Theme Stack"
 # Theme i18n support
 # See i18n folder for available languages

--- a/demo/config/_default/languages.toml
+++ b/demo/config/_default/languages.toml
@@ -1,31 +1,31 @@
 [en]
-    languageName = "English"
-    title        = "Hugo Theme Stack"
-    weight       = 1
+    label  = "English"
+    title  = "Hugo Theme Stack"
+    weight = 1
 
     [en.params.sidebar]
         subtitle = "Card-style Hugo theme designed for bloggers"
 
 [zh]
-    languageName = "简体中文"
-    title        = "Hugo 主题 Stack"
-    weight       = 2
+    label  = "简体中文"
+    title  = "Hugo 主题 Stack"
+    weight = 2
 
     [zh.params.sidebar]
         subtitle = "为博客设计的卡片式 Hugo 主题"
 
 [zh-hant-tw]
-    languageName = "正體中文"
-    title        = "Hugo 主題 Stack"
-    weight       = 3
+    label  = "正體中文"
+    title  = "Hugo 主題 Stack"
+    weight = 3
 
     [zh-hant-tw.params.sidebar]
         subtitle = "為博客設計的卡片式 Hugo 主題"
 
 [ja]
-    languageName = "日本語"
-    title        = "Hugo Theme Stack"
-    weight       = 4
+    label  = "日本語"
+    title  = "Hugo Theme Stack"
+    weight = 4
 
     [ja.params.sidebar]
         subtitle = "ブログ用のカードスタイルの Hugo テーマ"

--- a/layouts/_partials/article/components/details.html
+++ b/layouts/_partials/article/components/details.html
@@ -58,7 +58,7 @@
             <div class="inline-meta">
                 {{ partial "helper/icon" "language" }}
                 {{ range $Page.Translations }}
-                    <a href="{{ .RelPermalink }}" class="link">{{ .Language.LanguageName }}</a>
+                    <a href="{{ .RelPermalink }}" class="link">{{ .Language.Label }}</a>
                 {{ end }}
             </div>
         {{ end }}

--- a/layouts/_partials/sidebar/left.html
+++ b/layouts/_partials/sidebar/left.html
@@ -64,7 +64,7 @@
         {{ end }}
         <li class="menu-bottom-section">
             <ol class="menu">
-                {{- $currentLanguageCode := .Language.Lang -}}
+                {{- $currentLanguageCode := .Language.Name -}}
                 {{ if hugo.IsMultilingual }}
                     <li id="i18n-switch">  
                         {{ partial "helper/icon" "language" }}
@@ -72,11 +72,11 @@
                             {{ range .Site.Home.AllTranslations }}
                                 {{ $target := . }}
                                 {{ range $.AllTranslations }}
-                                    {{ if eq .Language.Lang $target.Language.Lang }}
+                                    {{ if eq .Language.Name $target.Language.Name }}
                                         {{ $target = . }}
                                     {{ end }}
                                 {{ end }}
-                                <option value="{{ $target.RelPermalink }}" {{ if eq $target.Language.Lang $currentLanguageCode }}selected{{ end }}>{{ .Language.LanguageName }}</option>
+                                <option value="{{ $target.RelPermalink }}" {{ if eq $target.Language.Name $currentLanguageCode }}selected{{ end }}>{{ .Language.Label }}</option>
                             {{ end }}
                         </select>
                     </li>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}" dir="{{ default `ltr` .Language.LanguageDirection }}">
+<html lang="{{ .Site.Language.Locale }}" dir="{{ default `ltr` .Language.Direction }}">
     <head>
         {{- partial "head/head.html" . -}}
         {{- block "head" . -}}{{ end }}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -30,7 +30,7 @@
         <link>{{ .Permalink }}</link>
         <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
         <generator>Hugo -- gohugo.io</generator>
-        <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+        <language>{{ site.Language.Locale }}</language>{{ with $authorEmail }}
         <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
         <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
         <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}


### PR DESCRIPTION
Reference: https://github.com/gohugoio/hugo/releases/tag/v0.158.0

When building the webpage, Hugo gives the following warnings:

```
WARN  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use locale instead.
WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.
WARN  deprecated: .Language.LanguageDirection was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Language.Direction instead.
WARN  deprecated: .Language.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Language.Locale instead.
```

This PR makes the following changes in code:

`.Site.LanguageCode` -> `.Site.Language.Locale`
`.Language.LanguageDirection` -> `.Language.Direction`
`.Language.LanguageCode` -> `.Language.Locale`

Additionally, in the configuration file `hugo.toml`, the user is expected to change `languageCode` to `locale`.